### PR TITLE
#14 feat : sign-out,withdrawal,ressiue

### DIFF
--- a/src/main/java/Journey/Together/domain/member/controller/AuthController.java
+++ b/src/main/java/Journey/Together/domain/member/controller/AuthController.java
@@ -5,8 +5,11 @@ import Journey.Together.domain.member.dto.LoginRes;
 import Journey.Together.domain.member.enumerate.LoginType;
 import Journey.Together.domain.member.service.AuthService;
 import Journey.Together.global.common.ApiResponse;
+import Journey.Together.global.exception.ApplicationException;
+import Journey.Together.global.exception.ErrorCode;
 import Journey.Together.global.exception.Success;
 import Journey.Together.global.security.PrincipalDetails;
+import Journey.Together.global.security.jwt.dto.TokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,5 +44,23 @@ public class AuthController {
         String token = request.getHeader("Authorization");
         authService.signOut(token, principalDetails.getMember());
         return ApiResponse.success(Success.SIGNOUT_SUCCESS);
+    }
+
+    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴 등록")
+    @PostMapping("/withdrawal")
+    public ApiResponse<Void> withdrawal(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        authService.withdrawal(principalDetails.getMember());
+        return ApiResponse.success(Success.DELETE_USER_SUCCESS);
+    }
+
+    @Operation(summary = "토큰재발급 API", description = "RefreshToken 정보로 요청 시, ")
+    @GetMapping("/reissue")
+    public ApiResponse<TokenDto> reissue(HttpServletRequest request, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String token = request.getHeader("Authorization");
+        // 헤더가 null이거나 Bearer로 시작하지 않으면 오류 처리
+        if (token == null || !token.startsWith("Bearer ")) {
+            return ApiResponse.success(Success.LOGIN_SUCCESS);
+        }
+        return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS,authService.reissue(token, principalDetails.getMember()));
     }
 }

--- a/src/main/java/Journey/Together/domain/member/service/AuthService.java
+++ b/src/main/java/Journey/Together/domain/member/service/AuthService.java
@@ -100,6 +100,7 @@ public class AuthService {
         tokenProvider.validateToken(accessToken);
 
         // Business Logic - Refresh Token 삭제 및 Access Token 블랙리스트 등록
+        tokenProvider.getExpiration(accessToken);
         member.setRefreshToken(null);
 
         // Response
@@ -116,15 +117,14 @@ public class AuthService {
     }
 
     public TokenDto reissue(String token, Member member) {
+        System.out.println(token);
         // Validation - RefreshToken 유효성 검증
         String refreshToken = token.substring(7);
         tokenProvider.validateToken(refreshToken);
         String memberRefreshToken = member.getRefreshToken();
-        // 입력받은 refreshToken과 Redis의 RefreshToken 간의 일치 여부 검증
         if(refreshToken.isBlank() || memberRefreshToken.isEmpty() || !memberRefreshToken.equals(refreshToken)) {
             throw new ApplicationException(ErrorCode.WRONG_TOKEN_EXCEPTION);
         }
-
         // Business Logic & Response - Access Token 새로 발급 + Refresh Token의 유효 기간이 Access Token의 유효 기간보다 짧아졌을 경우 Refresh Token도 재발급
         return tokenProvider.reissue(member, refreshToken);
     }

--- a/src/main/java/Journey/Together/global/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/Journey/Together/global/security/jwt/JwtAccessDeniedHandler.java
@@ -31,7 +31,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     private void setResponse(HttpServletResponse response) throws IOException{
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(ErrorCode.FORBIDDEN_EXCEPTION.getHttpStatus().value());
-
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.FORBIDDEN_EXCEPTION);
         String errorJson = objectMapper.writeValueAsString(errorResponse);
 


### PR DESCRIPTION
## 🚩 관련 이슈
- #14 

## 📋 구현 기능 명세
- [ ] controller, service 구현

## 📌 PR Point
로그아웃 - refreshToken null로 변경 안됌
회원 탈퇴 - 카카오와 네이버에서 연결 끊기 구현 안되어있음
토큰 재발급 - 오류 발생
