### PR TITLE
feat : 일정 후기 작성 api, 로그인 시 s3 folder 생성

### DIFF
--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -34,4 +34,9 @@ public class PlanController {
         return ApiResponse.success(Success.DELETE_PLAN_SUCCESS);
     }
 
+    @PostMapping("/review/{plan_id}")
+    public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("plan_id")Long planId){
+        return ApiResponse.success(Success.CREATE_REVIEW_SUCCESS);
+    }
+
 }

--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -10,6 +10,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,9 +39,8 @@ public class PlanController {
     }
 
     @PostMapping("/review/{plan_id}")
-    public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId, @RequestBody PlanReviewReq planReviewReq){
-        planService.savePlanReview(principalDetails.getMember(),planId,planReviewReq);
+    public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId, @RequestPart(required = false) List<MultipartFile> images, @RequestPart PlanReviewReq planReviewReq){
+        planService.savePlanReview(principalDetails.getMember(),planId,planReviewReq,images);
         return ApiResponse.success(Success.CREATE_REVIEW_SUCCESS);
     }
-
 }

--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -1,6 +1,7 @@
 package Journey.Together.domain.dairy.controller;
 
 import Journey.Together.domain.dairy.dto.PlanReq;
+import Journey.Together.domain.dairy.dto.PlanReviewReq;
 import Journey.Together.domain.dairy.service.PlanService;
 import Journey.Together.global.common.ApiResponse;
 import Journey.Together.global.exception.Success;
@@ -35,7 +36,8 @@ public class PlanController {
     }
 
     @PostMapping("/review/{plan_id}")
-    public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("plan_id")Long planId){
+    public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId, @RequestBody PlanReviewReq planReviewReq){
+        planService.savePlanReview(principalDetails.getMember(),planId,planReviewReq);
         return ApiResponse.success(Success.CREATE_REVIEW_SUCCESS);
     }
 

--- a/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewReq.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewReq.java
@@ -2,11 +2,13 @@ package Journey.Together.domain.dairy.dto;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.swing.text.StyledEditorKit;
 import java.util.List;
 
 public record PlanReviewReq(
         float grade,
         String content,
-        List<MultipartFile> images
+        List<MultipartFile> images,
+        Boolean isPublic
 ) {
 }

--- a/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewReq.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewReq.java
@@ -1,0 +1,12 @@
+package Journey.Together.domain.dairy.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record PlanReviewReq(
+        float grade,
+        String content,
+        List<MultipartFile> images
+) {
+}

--- a/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewReq.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewReq.java
@@ -8,7 +8,6 @@ import java.util.List;
 public record PlanReviewReq(
         float grade,
         String content,
-        List<MultipartFile> images,
         Boolean isPublic
 ) {
 }

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReview.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReview.java
@@ -25,11 +25,11 @@ public class PlanReview extends BaseTimeEntity {
     @Column(name = "content",columnDefinition = "varchar(300)")
     private String content;
 
-    @OneToOne(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToOne
     @JoinColumn(name = "plan_id")
     private Plan plan;
 
-    @OneToMany(mappedBy = "planReviewImage", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "planReview", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<PlanReviewImage> planReviewImages = new ArrayList<>();
 
     @Builder

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReview.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReview.java
@@ -1,0 +1,34 @@
+package Journey.Together.domain.dairy.entity;
+
+import Journey.Together.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "planReview")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlanReview extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "planReview_id",columnDefinition = "bigint")
+    private Long planReviewId;
+
+    @OneToOne(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    @OneToMany(mappedBy = "planReviewImage", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<PlanReviewImage> planReviewImages = new ArrayList<>();
+
+    @Column(name = "grade")
+    private float grade;
+
+    @Column(name = "content",columnDefinition = "varchar(300)")
+    private String content;
+}

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReview.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReview.java
@@ -19,6 +19,12 @@ public class PlanReview extends BaseTimeEntity {
     @Column(name = "planReview_id",columnDefinition = "bigint")
     private Long planReviewId;
 
+    @Column(name = "grade")
+    private float grade;
+
+    @Column(name = "content",columnDefinition = "varchar(300)")
+    private String content;
+
     @OneToOne(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
@@ -26,9 +32,11 @@ public class PlanReview extends BaseTimeEntity {
     @OneToMany(mappedBy = "planReviewImage", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<PlanReviewImage> planReviewImages = new ArrayList<>();
 
-    @Column(name = "grade")
-    private float grade;
-
-    @Column(name = "content",columnDefinition = "varchar(300)")
-    private String content;
+    @Builder
+    public PlanReview(float grade, String content,Plan plan,List<PlanReviewImage> planReviewImages){
+        this.grade = grade;
+        this.content=content;
+        this.plan=plan;
+        this.planReviewImages=planReviewImages;
+    }
 }

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
@@ -17,4 +17,9 @@ public class PlanReviewImage {
 
     @Column(name = "imageUrl")
     private String imageUrl;
+
+    @Builder
+    public PlanReviewImage(String imageUrl){
+        this.imageUrl=imageUrl;
+    }
 }

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
@@ -1,5 +1,6 @@
 package Journey.Together.domain.dairy.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,6 +15,10 @@ public class PlanReviewImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "planReviewImage_id")
     private Long planReviewImageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "planReview_id", nullable = false, columnDefinition = "bigint")
+    private PlanReview planReview;
 
     @Column(name = "imageUrl")
     private String imageUrl;

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
@@ -24,7 +24,8 @@ public class PlanReviewImage {
     private String imageUrl;
 
     @Builder
-    public PlanReviewImage(String imageUrl){
+    public PlanReviewImage(String imageUrl,PlanReview planReview){
         this.imageUrl=imageUrl;
+        this.planReview= planReview;
     }
 }

--- a/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
+++ b/src/main/java/Journey/Together/domain/dairy/entity/PlanReviewImage.java
@@ -1,0 +1,20 @@
+package Journey.Together.domain.dairy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "palnReviewImage")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlanReviewImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "planReviewImage_id")
+    private Long planReviewImageId;
+
+    @Column(name = "imageUrl")
+    private String imageUrl;
+}

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
@@ -4,7 +4,10 @@ import Journey.Together.domain.dairy.entity.Plan;
 import Journey.Together.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     Plan findPlanByMemberAndPlanIdAndDeletedAtIsNull(Member member,Long planId);
+    Plan findPlanByMemberAndPlanIdAndEndDateIsAfterAndDeletedAtIsNull(Member member, Long planId, LocalDate today);
     void deletePlanByPlanId(Long id);
 }

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
@@ -8,6 +8,6 @@ import java.time.LocalDate;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     Plan findPlanByMemberAndPlanIdAndDeletedAtIsNull(Member member,Long planId);
-    Plan findPlanByMemberAndPlanIdAndEndDateIsAfterAndDeletedAtIsNull(Member member, Long planId, LocalDate today);
+    Plan findPlanByMemberAndPlanIdAndEndDateIsBeforeAndDeletedAtIsNull(Member member, Long planId, LocalDate today);
     void deletePlanByPlanId(Long id);
 }

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanReviewImageRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanReviewImageRepository.java
@@ -1,0 +1,7 @@
+package Journey.Together.domain.dairy.repository;
+
+import Journey.Together.domain.dairy.entity.PlanReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanReviewImageRepository extends JpaRepository<PlanReviewImage,Long> {
+}

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanReviewRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanReviewRepository.java
@@ -1,0 +1,8 @@
+package Journey.Together.domain.dairy.repository;
+
+import Journey.Together.domain.dairy.entity.PlanReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface PlanReviewRepository extends JpaRepository<PlanReview,Long> {
+}

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -116,5 +116,6 @@ public class PlanService {
                 .build();
         planReviewRepository.save(planReview);
 
+        plan.setIsPublic(planReviewReq.isPublic());
     }
 }

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.Date;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -72,6 +75,17 @@ public class PlanService {
         //Buisness
         dayRepository.deleteAllByMemberAndPlan(member,plan);
         planRepository.deletePlanByPlanId(planId);
+
+    }
+
+    @Transactional
+    public void savePlanReview(Member member,Long planId){
+        // Validation
+        Plan plan = planRepository.findPlanByMemberAndPlanIdAndEndDateIsAfterAndDeletedAtIsNull(member,planId,LocalDate.now());
+        if(plan == null){
+            throw new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION);
+        }
+
 
     }
 }

--- a/src/main/java/Journey/Together/domain/member/service/AuthService.java
+++ b/src/main/java/Journey/Together/domain/member/service/AuthService.java
@@ -61,7 +61,8 @@ public class AuthService {
             // 이메일 존재 시 로그인 , 존재하지 않을 경우 회원가입 진행
             if(member == null) {
                 MultipartFile imageFile = convertUrlToMultipartFile(kakaoProfile.kakao_account().profile().profile_image_url());
-                String uuid = s3Client.upload(imageFile);
+                String uuid = s3Client.createFolder();
+                s3Client.upload(imageFile,uuid,"profiile");
                 Member newMember = Member.builder()
                         .email(kakaoProfile.kakao_account().email())
                         .name(kakaoProfile.kakao_account().profile().nickname())
@@ -93,7 +94,8 @@ public class AuthService {
 
             if (member == null) {
                 MultipartFile imageFile = convertUrlToMultipartFile(naverProfile.getProfile_image() != null ? naverProfile.getProfile_image() : null);
-                String uuid = s3Client.upload(imageFile);
+                String uuid = s3Client.createFolder();
+                s3Client.upload(imageFile,uuid,"profiile");
 
                 Member newMember = Member.builder()
                         .email(naverProfile.getEmail() != null ? naverProfile.getEmail() : "Unknown")

--- a/src/main/java/Journey/Together/domain/member/service/MemberService.java
+++ b/src/main/java/Journey/Together/domain/member/service/MemberService.java
@@ -30,7 +30,7 @@ public class MemberService {
 
     public MyPageRes getMypage(Member member){
         Long date = Duration.between(member.getCreatedAt(), LocalDateTime.now()).toDays();
-        return new MyPageRes(member.getName(), 0, date, member.getProfileUuid());
+        return new MyPageRes(member.getName(), 0, date, member.getProfileUuid()+"/profile");
     }
   
     @Transactional
@@ -82,7 +82,7 @@ public class MemberService {
         // Validation
         memberRepository.findMemberByEmailAndDeletedAtIsNull(member.getEmail()).orElseThrow(()->new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
         //Business
-        MemberRes memberRes = MemberRes.of(member, s3Client.getUrl()+member.getProfileUuid());
+        MemberRes memberRes = MemberRes.of(member, s3Client.getUrl()+member.getProfileUuid()+"/profile");
         //Response
         return memberRes;
     }

--- a/src/main/java/Journey/Together/global/exception/Success.java
+++ b/src/main/java/Journey/Together/global/exception/Success.java
@@ -13,7 +13,7 @@ public enum Success {
 	 */
 	CREATE_PLAN_SUCCESS(HttpStatus.CREATED, "일정 저장이 완료 되었습니다."),
 	CREATE_CATEGORY_SUCCESS(HttpStatus.CREATED, "새 카테고리 추가 성공"),
-	CREATE_TIMER_SUCCESS(HttpStatus.CREATED, "새 타이머 생성 성공"),
+	CREATE_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰 생성 성공"),
 
 	/**
 	 * 200 OK

--- a/src/main/java/Journey/Together/global/util/S3Client.java
+++ b/src/main/java/Journey/Together/global/util/S3Client.java
@@ -53,7 +53,7 @@ public class S3Client {
         }
 
         // Response
-        return uuid;
+        return baseUrl+url;
     }
 
     public String update(String fileName, MultipartFile newFile) {


### PR DESCRIPTION
## 🚩 관련 이슈
- #31 

## 📋 구현 기능 명세
- [x] 일정 후기 작성 api 구현
- [x] 로그인 시 s3 folder 생성

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
로그인 시 s3에 member uuid를 생성하여 uuid를 폴더 이름으로 생성

- 어떤 부분에 리뷰어가 집중해야 하는지
일정 후기 등록 시 여러사진들을 List<MultipartFile> 형식으로 받음. 이때 여러 사진들을 올리면 각 사진마다 uuid를 생성하여 member 고유의 폴더 내에 저장

- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="761" alt="스크린샷 2024-06-03 오후 10 02 33" src="https://github.com/Journey-Together/Server/assets/102959791/7704620d-8f3f-4707-9d1a-b1c6c1ccbdfd">
<img width="1053" alt="스크린샷 2024-06-04 오후 9 35 14" src="https://github.com/Journey-Together/Server/assets/102959791/4fc7cab0-cb24-4e9a-8395-68d7477d4afd">
<img width="736" alt="스크린샷 2024-06-04 오후 9 35 30" src="https://github.com/Journey-Together/Server/assets/102959791/9a464680-41fa-461c-b7de-78c755f8da67">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
