### PR TITLE
feat : 내 일정 정보 api 

### DIFF
--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -34,4 +34,8 @@ public class PlanController {
         return ApiResponse.success(Success.DELETE_PLAN_SUCCESS);
     }
 
+    @GetMapping("/my")
+    public ApiResponse findMyPlans(@AuthenticationPrincipal PrincipalDetails principalDetails){
+        return ApiResponse.success(Success.GET_MYPLAN_SUCCESS);
+    }
 }

--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -1,5 +1,6 @@
 package Journey.Together.domain.dairy.controller;
 
+import Journey.Together.domain.dairy.dto.MyPlanRes;
 import Journey.Together.domain.dairy.dto.PlanReq;
 import Journey.Together.domain.dairy.dto.PlanReviewReq;
 import Journey.Together.domain.dairy.service.PlanService;
@@ -46,7 +47,7 @@ public class PlanController {
     }
 
     @GetMapping("/my")
-    public ApiResponse findMyPlans(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(Success.GET_MYPLAN_SUCCESS);
+    public ApiResponse<List<MyPlanRes>> findMyPlans(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.success(Success.GET_MYPLAN_SUCCESS,planService.findMyPlans(principalDetails.getMember()));
     }
 }

--- a/src/main/java/Journey/Together/domain/dairy/dto/MyPlanRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/MyPlanRes.java
@@ -1,0 +1,32 @@
+package Journey.Together.domain.dairy.dto;
+
+import Journey.Together.domain.dairy.entity.Plan;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Null;
+import lombok.Builder;
+
+import java.time.LocalDate;
+@Builder
+public record MyPlanRes(
+        Long planId,
+        String title,
+        LocalDate startDate,
+        LocalDate endDate,
+        String imageUrl,
+        @Null
+        String remainDate,
+        @Null
+        Boolean hasReview
+) {
+    public static MyPlanRes of (Plan plan,String imageUrl,String remainDate,Boolean hasReview){
+        return MyPlanRes.builder()
+                .planId(plan.getPlanId())
+                .title(plan.getTitle())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .imageUrl(imageUrl)
+                .remainDate(remainDate)
+                .hasReview(hasReview)
+                .build();
+    }
+}

--- a/src/main/java/Journey/Together/domain/dairy/repository/DayRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/DayRepository.java
@@ -5,9 +5,11 @@ import Journey.Together.domain.dairy.entity.Plan;
 import Journey.Together.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface DayRepository extends JpaRepository<Day,Long> {
 
     void deleteAllByMemberAndPlan (Member member, Plan plan);
+    List<Day> findByMemberAndDateAndPlan(Member member, LocalDate date, Plan plan);
 }

--- a/src/main/java/Journey/Together/domain/dairy/repository/DayRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/DayRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface DayRepository extends JpaRepository<Day,Long> {
 
     void deleteAllByMemberAndPlan (Member member, Plan plan);
-    List<Day> findByMemberAndDateAndPlan(Member member, LocalDate date, Plan plan);
+    List<Day> findByMemberAndDateAndPlanOrderByCreatedAtDesc(Member member, LocalDate date, Plan plan);
 }

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
@@ -4,7 +4,10 @@ import Journey.Together.domain.dairy.entity.Plan;
 import Journey.Together.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     Plan findPlanByMemberAndPlanIdAndDeletedAtIsNull(Member member,Long planId);
+    List<Plan> findAllByMemberAndDeletedAtIsNull(Member member);
     void deletePlanByPlanId(Long id);
 }

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
@@ -4,6 +4,7 @@ import Journey.Together.domain.dairy.entity.Plan;
 import Journey.Together.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanReviewRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanReviewRepository.java
@@ -1,8 +1,10 @@
 package Journey.Together.domain.dairy.repository;
 
+import Journey.Together.domain.dairy.entity.Plan;
 import Journey.Together.domain.dairy.entity.PlanReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface PlanReviewRepository extends JpaRepository<PlanReview,Long> {
+    boolean existsAllByPlan(Plan plan);
 }

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -132,7 +132,7 @@ public class PlanService {
         //Business
         List<MyPlanRes> myPlanResList = new ArrayList<>();
         for(Plan plan : list){
-            List<Day> dayList = dayRepository.findByMemberAndDateAndPlan(member,plan.getStartDate(),plan);
+            List<Day> dayList = dayRepository.findByMemberAndDateAndPlanOrderByCreatedAtDesc(member,plan.getStartDate(),plan);
             String image = dayList.get(0).getPlace().getFirstImg();
             if (LocalDate.now().isBefore(plan.getEndDate())){
                 //true : 이후 날짜

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -74,4 +74,8 @@ public class PlanService {
         planRepository.deletePlanByPlanId(planId);
 
     }
+    @Transactional
+    public void findMyPlans(Member member){
+
+    }
 }

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -162,7 +162,7 @@ public class PlanService {
                         .startDate(plan.getStartDate())
                         .endDate(plan.getEndDate())
                         .imageUrl(image)
-                        .remainDate("D - "+ period.getDays())
+                        .remainDate("D-"+ period.getDays())
                         .hasReview(null)
                         .build();
                 myPlanResList.add(myPlanRes);

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -142,6 +142,7 @@ public class PlanService {
                 Boolean hasReview = planReviewRepository.existsAllByPlan(plan);
                 MyPlanRes myPlanRes = MyPlanRes.builder()
                         .planId(plan.getPlanId())
+                        .title(plan.getTitle())
                         .startDate(plan.getStartDate())
                         .endDate(plan.getEndDate())
                         .imageUrl(image)
@@ -157,6 +158,7 @@ public class PlanService {
                 Period period = Period.between(plan.getStartDate(),plan.getEndDate());
                 MyPlanRes myPlanRes = MyPlanRes.builder()
                         .planId(plan.getPlanId())
+                        .title(plan.getTitle())
                         .startDate(plan.getStartDate())
                         .endDate(plan.getEndDate())
                         .imageUrl(image)

--- a/src/main/java/Journey/Together/global/exception/Success.java
+++ b/src/main/java/Journey/Together/global/exception/Success.java
@@ -23,7 +23,7 @@ public enum Success {
 	GET_MAIN_SUCCESS(HttpStatus.OK, "메인 페이지 정보 조회 성공"),
 	GET_PLACE_DETAIL_SUCCESS(HttpStatus.OK, "여행지 상세정보 조회 성공"),
 	GET_MYPAGE_SUCCESS(HttpStatus.OK, "마이 페이지 조회 성공"),
-	GET_LINKS_SUCCESS(HttpStatus.OK, "이주의 링크 조회 성공"),
+	GET_MYPLAN_SUCCESS(HttpStatus.OK, "내 일정 조회 성공"),
 	GET_SITES_SUCCESS(HttpStatus.OK, "추천 사이트 조회 성공"),
 	GET_SETTINGS_SUCCESS(HttpStatus.OK, "설정 페이지 조회 성공"),
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #30 

## 📋 구현 기능 명세
- [x] 내 일정 정보 저장 api
null
## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지
일정 시작하는 날 기준의 첫번째 장소 사진으로 이미지를 보내도록 했는데 이 장소 사진이 없으면 null값으로 보내집니다.


- 개발하면서 어떤 점이 궁금했는지
 findMyPlans 메소드에서 jpa를 잘 활용했는지 궁금합니다

## 📸 결과물 스크린샷
<img width="699" alt="스크린샷 2024-06-04 오후 10 06 07" src="https://github.com/Journey-Together/Server/assets/102959791/7de0b028-2df7-4c0e-9f08-721efec762e5">
<img width="698" alt="스크린샷 2024-06-04 오후 10 06 12" src="https://github.com/Journey-Together/Server/assets/102959791/b7eacabe-f2f1-427a-913c-06b41cf2cb4c">
<img width="668" alt="스크린샷 2024-06-05 오전 1 26 00" src="https://github.com/Journey-Together/Server/assets/102959791/c9134bcc-50bb-4055-ad4d-ee94fdb824e2">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /v1/plan/my
