### PR TITLE
feat : 일정 관련 페이지네이션 api 구현

### DIFF
--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -55,4 +55,9 @@ public class PlanController {
     public ApiResponse<PlaceInfoPageRes> searchPlace(@RequestParam String word, @PageableDefault(size = 6,page = 0) Pageable pageable){
         return ApiResponse.success(Success.SEARCH_SUCCESS,planService.searchPlace(word,pageable));
     }
+
+    @GetMapping("/my/not-complete")
+    public ApiResponse<PlanPageRes> findNotComplete(@AuthenticationPrincipal PrincipalDetails principalDetails,@PageableDefault(size = 6,page = 0) Pageable pageable){
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findNotComplete(principalDetails.getMember(),pageable));
+    }
 }

--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -2,6 +2,7 @@ package Journey.Together.domain.dairy.controller;
 
 import Journey.Together.domain.dairy.dto.*;
 import Journey.Together.domain.dairy.service.PlanService;
+import Journey.Together.domain.member.entity.Member;
 import Journey.Together.global.common.ApiResponse;
 import Journey.Together.global.exception.Success;
 import Journey.Together.global.security.PrincipalDetails;
@@ -44,10 +45,20 @@ public class PlanController {
         return ApiResponse.success(Success.DELETE_PLAN_SUCCESS);
     }
 
+    @GetMapping("/search")
+    public ApiResponse<PlaceInfoPageRes> searchPlace(@RequestParam String word, @PageableDefault(size = 6,page = 0) Pageable pageable){
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.searchPlace(word,pageable));
+    }
+
     @PostMapping("/review/{plan_id}")
     public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId, @RequestPart(required = false) List<MultipartFile> images, @RequestPart PlanReviewReq planReviewReq){
         planService.savePlanReview(principalDetails.getMember(),planId,planReviewReq,images);
         return ApiResponse.success(Success.CREATE_REVIEW_SUCCESS);
+    }
+
+    @GetMapping("/open")
+    public ApiResponse<OpenPlanPageRes> findOpenPlans(@PageableDefault(size = 6) Pageable pageable){
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findOpenPlans(pageable));
     }
 
     @GetMapping("/my")
@@ -55,14 +66,13 @@ public class PlanController {
         return ApiResponse.success(Success.GET_MYPLAN_SUCCESS,planService.findMyPlans(principalDetails.getMember()));
     }
 
-    @GetMapping("/search")
-    public ApiResponse<PlaceInfoPageRes> searchPlace(@RequestParam String word, @PageableDefault(size = 6,page = 0) Pageable pageable){
-        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.searchPlace(word,pageable));
-    }
-    
     @GetMapping("/my/not-complete")
     public ApiResponse<PlanPageRes> findNotComplete(@AuthenticationPrincipal PrincipalDetails principalDetails,@PageableDefault(size = 6,page = 0) Pageable pageable){
         return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findNotComplete(principalDetails.getMember(),pageable));
+    }
+    @GetMapping("/my/complete")
+    public ApiResponse<PlanPageRes> findComplete(@AuthenticationPrincipal PrincipalDetails principalDetails,@PageableDefault(size = 6) Pageable pageable){
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findComplete(principalDetails.getMember(),pageable));
     }
 
 }

--- a/src/main/java/Journey/Together/domain/dairy/dto/MyPlanRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/MyPlanRes.java
@@ -1,7 +1,6 @@
 package Journey.Together.domain.dairy.dto;
 
 import Journey.Together.domain.dairy.entity.Plan;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Null;
 import lombok.Builder;
 

--- a/src/main/java/Journey/Together/domain/dairy/dto/OpenPlanPageRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/OpenPlanPageRes.java
@@ -1,0 +1,28 @@
+package Journey.Together.domain.dairy.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OpenPlanPageRes(
+        List<OpenPlanRes> openPlanResList,
+        int pageNo,
+        int pageSize,
+        int totalPages,
+        boolean last
+) {
+    public static OpenPlanPageRes of(List<OpenPlanRes> openPlanResList,
+                                 int pageNo,
+                                 int pageSize,
+                                 int totalPages,
+                                 boolean last){
+        return OpenPlanPageRes.builder()
+                .openPlanResList(openPlanResList)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .totalPages(totalPages)
+                .last(last)
+                .build();
+    }
+}

--- a/src/main/java/Journey/Together/domain/dairy/dto/OpenPlanRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/OpenPlanRes.java
@@ -1,0 +1,32 @@
+package Journey.Together.domain.dairy.dto;
+
+import Journey.Together.domain.dairy.entity.Plan;
+import lombok.Builder;
+
+import java.time.Period;
+
+@Builder
+public record OpenPlanRes(
+        Long planId,
+        String title,
+        String placeImageUrl,
+        Long memberId,
+        String memberName,
+        String memberImageUrl,
+        String date
+) {
+    public static OpenPlanRes of(Plan plan,String memberImageUrl,String placeImageUrl){
+        Period period = Period.between(plan.getStartDate(),plan.getEndDate());
+        String date = period.getDays()+"일일정";
+
+        return OpenPlanRes.builder()
+                .planId(plan.getPlanId())
+                .title(plan.getTitle())
+                .placeImageUrl(placeImageUrl)
+                .memberId(plan.getMember().getMemberId())
+                .memberName(plan.getMember().getName())
+                .memberImageUrl(memberImageUrl)
+                .date(date)
+                .build();
+    }
+}

--- a/src/main/java/Journey/Together/domain/dairy/dto/PlanPageRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/PlanPageRes.java
@@ -1,0 +1,4 @@
+package Journey.Together.domain.dairy.dto;
+
+public record PlanPageRes() {
+}

--- a/src/main/java/Journey/Together/domain/dairy/dto/PlanPageRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/PlanPageRes.java
@@ -1,4 +1,30 @@
 package Journey.Together.domain.dairy.dto;
 
-public record PlanPageRes() {
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Builder
+public record PlanPageRes(
+        List<PlanRes> planResList,
+        int pageNo,
+        int pageSize,
+        int totalPages,
+        boolean last
+) {
+    public static PlanPageRes of(List<PlanRes> planResList,
+                                      int pageNo,
+                                      int pageSize,
+                                      int totalPages,
+                                      boolean last){
+        return PlanPageRes.builder()
+                .planResList(planResList)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .totalPages(totalPages)
+                .last(last)
+                .build();
+    }
 }

--- a/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
+++ b/src/main/java/Journey/Together/domain/dairy/repository/PlanRepository.java
@@ -2,6 +2,8 @@ package Journey.Together.domain.dairy.repository;
 
 import Journey.Together.domain.dairy.entity.Plan;
 import Journey.Together.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -12,5 +14,10 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     List<Plan> findAllByMemberAndDeletedAtIsNull(Member member);
     Plan findPlanByMemberAndPlanIdAndEndDateIsBeforeAndDeletedAtIsNull(Member member, Long planId, LocalDate today);
     void deletePlanByPlanId(Long id);
+    // 오늘을 포함하지 않고 지난 계획들
+    Page<Plan> findAllByMemberAndEndDateBeforeAndDeletedAtIsNull(Member member, LocalDate today, Pageable pageable);
+    // 오늘을 포함하여 지나지 않은 계획들
+    Page<Plan> findAllByMemberAndEndDateGreaterThanEqualAndDeletedAtIsNull(Member member, LocalDate today, Pageable pageable);
+    Page<Plan> findAllByEndDateBeforeAndIsPublicIsTrueAndDeletedAtIsNull(LocalDate today,Pageable pageable);
 
 }

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -136,20 +136,15 @@ public class PlanService {
         for(Plan plan : list){
             List<Day> dayList = dayRepository.findByMemberAndDateAndPlanOrderByCreatedAtDesc(member,plan.getStartDate(),plan);
             String image = dayList.get(0).getPlace().getFirstImg();
-            if (LocalDate.now().isBefore(plan.getEndDate())){
-                //true : 이후 날짜
-                //imageUrl - startDate의 장소 중 가장 첫번째(createdAt 기준) //이건... 그냥 이야기 해봐야댈뜻..
-                //remainDate - null
-                //hasReview : review 찾아서 null 값이면 false 아니면 true
+            if (LocalDate.now().isAfter(plan.getEndDate())){
                 Boolean hasReview = planReviewRepository.existsAllByPlan(plan);
                 MyPlanRes myPlanRes = MyPlanRes.of(plan,image,null,hasReview);
                 myPlanResList.add(myPlanRes);
-            }else{
-                //false : 이전 날짜
-                //imageUrl - startDate의 장소 중 가장 첫번째(createdAt 기준)
-                //remainDate - endDate-startDate
-                //hasReview : null
-                Period period = Period.between(plan.getStartDate(),plan.getEndDate());
+            }else if ((LocalDate.now().isEqual(plan.getStartDate()) || LocalDate.now().isAfter(plan.getStartDate())) && (LocalDate.now().isEqual(plan.getEndDate()) || LocalDate.now().isBefore(plan.getEndDate()))){
+                MyPlanRes myPlanRes = MyPlanRes.of(plan,image,"D-DAY",null);
+                myPlanResList.add(myPlanRes);
+            }else if (LocalDate.now().isBefore(plan.getStartDate())){
+                Period period = Period.between(LocalDate.now(),plan.getStartDate());
                 MyPlanRes myPlanRes = MyPlanRes.of(plan,image,"D-"+ period.getDays(),null);
                 myPlanResList.add(myPlanRes);
             }

--- a/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
+++ b/src/main/java/Journey/Together/domain/dairy/service/PlanService.java
@@ -163,4 +163,9 @@ public class PlanService {
                 .collect(Collectors.toList());
         return PlaceInfoPageRes.of(placeInfoList, placePage.getNumber(), placePage.getSize(), placePage.getTotalPages(), placePage.isLast());
     }
+
+    @Transactional
+    public PlanPageRes findNotComplete(Member member,Pageable page){
+
+    }
 }

--- a/src/main/java/Journey/Together/global/util/S3Client.java
+++ b/src/main/java/Journey/Together/global/util/S3Client.java
@@ -24,6 +24,10 @@ public class S3Client {
     @Value("${aws-property.baseUrl}")
     private String baseUrl;
 
+    public String baseUrl(){
+        return this.baseUrl;
+    }
+
     public String createFolder(){
         String folderName = UUID.randomUUID().toString();
         amazonS3Client.putObject(bucket, folderName + "/", new ByteArrayInputStream(new byte[0]), new ObjectMetadata());


### PR DESCRIPTION
## 🚩 관련 이슈
- close #38 

## 📋 구현 기능 명세
- [x] 다녀온 일정 api
- [x] 다가오는 일정 api
- [x] 공개된 일정 api

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
/my 부분에서 3개의 데이터만 보내지고 현재의 날짜 기준으로 과거,현재 상관없이 가장 날짜가 가까운 데이터 3개를 추출하였습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
다가오는 일정과 다녀온 일정들을 같은 dto을 사용하여 필요하지 않은 데이터 값은 null어노테이션을 이용한 후 json에 포함 시키지 않도록 구현했습니다

- 개발하면서 어떤 점이 궁금했는지


## 📸 결과물 스크린샷
<img width="698" alt="스크린샷 2024-06-05 오후 4 03 53" src="https://github.com/Journey-Together/Server/assets/102959791/88ee5a24-82ce-447f-afc5-eb2c38f57cc5">
<img width="685" alt="스크린샷 2024-06-05 오후 4 15 19" src="https://github.com/Journey-Together/Server/assets/102959791/790b131e-4a55-4214-b680-789566be298f">
<img width="686" alt="스크린샷 2024-06-05 오후 4 18 55" src="https://github.com/Journey-Together/Server/assets/102959791/6bbab8a8-bb68-47fd-ad69-a2cfcc51502d">



## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /v1/plan/open , /v1/plan/my, /v1/plan/my/complete, /v1/plan/my/not-complete