### PR TITLE
feat : 일정 후기 정보와 게스트일 경우 api 구현

### DIFF
--- a/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/dairy/controller/PlanController.java
@@ -57,6 +57,16 @@ public class PlanController {
         return ApiResponse.success(Success.CREATE_REVIEW_SUCCESS);
     }
 
+    @GetMapping("/review/{plan_id}")
+    public ApiResponse<PlanReviewRes> findPlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId){
+        return ApiResponse.success(Success.GET_REVIEW_SUCCESS,planService.findPlanReview(principalDetails.getMember(),planId));
+    }
+
+    @GetMapping("/guest/review/{plan_id}")
+    public ApiResponse<PlanReviewRes> findPlanReviewGuest(@PathVariable("plan_id")Long planId){
+        return ApiResponse.success(Success.GET_REVIEW_SUCCESS,planService.findPlanReview(null,planId));
+    }
+
     @GetMapping("/open")
     public ApiResponse<OpenPlanPageRes> findOpenPlans(@PageableDefault(size = 6) Pageable pageable){
         return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findOpenPlans(pageable));
@@ -65,6 +75,11 @@ public class PlanController {
     @GetMapping("/detail/{plan_id}")
     public ApiResponse<PlanDetailRes> findPalnDetailInfo(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId){
         return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findPlanDetail(principalDetails.getMember(),planId));
+    }
+
+    @GetMapping("/guest/detail/{plan_id}")
+    public ApiResponse<PlanDetailRes> findPalnDetailInfo(@PathVariable("plan_id")Long planId){
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findPlanDetail(null,planId));
     }
 
     @GetMapping("/my")

--- a/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewRes.java
+++ b/src/main/java/Journey/Together/domain/dairy/dto/PlanReviewRes.java
@@ -1,0 +1,31 @@
+package Journey.Together.domain.dairy.dto;
+
+import Journey.Together.domain.dairy.entity.PlanReview;
+import jakarta.validation.constraints.Null;
+import lombok.Builder;
+
+@Builder
+public record PlanReviewRes(
+        @Null
+        Long reviewId,
+        @Null
+        String content,
+        @Null
+        Float grade,
+        @Null
+        boolean isWriter,
+        @Null
+        boolean hasReview
+) {
+    public static PlanReviewRes of(Long reviewId,
+                                   String content,
+                                   Float grade,boolean isWriter,boolean hasReview){
+        return PlanReviewRes.builder()
+                .reviewId(reviewId)
+                .content(content)
+                .grade(grade)
+                .isWriter(isWriter)
+                .hasReview(hasReview)
+                .build();
+    }
+}

--- a/src/main/java/Journey/Together/global/config/SecurityConfig.java
+++ b/src/main/java/Journey/Together/global/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/v1/member/**").authenticated()
                         .requestMatchers("/v1/place/main").permitAll()
+                        .requestMatchers("/v1/plan/guest/**").permitAll()
                         // 메인 페이지, 공고 페이지 등에 한해 인증 정보 없이 접근 가능 (추후 추가)
                         // 이외의 모든 요청은 인증 정보 필요
                         .anyRequest().authenticated());

--- a/src/main/java/Journey/Together/global/exception/Success.java
+++ b/src/main/java/Journey/Together/global/exception/Success.java
@@ -26,7 +26,7 @@ public enum Success {
 	GET_MYPLAN_SUCCESS(HttpStatus.OK, "내 일정 조회 성공"),
 	GET_PLAN_SUCCESS(HttpStatus.OK, "내 일정 조회 성공"),
 	GET_SITES_SUCCESS(HttpStatus.OK, "추천 사이트 조회 성공"),
-	GET_SETTINGS_SUCCESS(HttpStatus.OK, "설정 페이지 조회 성공"),
+	GET_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 조회 성공"),
 
 	GET_CATEORIES_SUCCESS(HttpStatus.OK, "전체 카테고리 조회 성공"),
 	GET_CATEORY_SUCCESS(HttpStatus.OK, "세부 카테고리 조회 성공"),


### PR DESCRIPTION
## 🚩 관련 이슈
- close #45 

## 📋 구현 기능 명세
- [x] 일정 후기 정보 api
- [x] 게스트일 경우 일정 후기 정보 api
- [x] 게스트일 경우 일정 자세히 보기 정보 api

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
게스트일 경우 token을 받아야 하지 않기 때문에 SecrityConfig에 /v1/plan/guest/**을 추가 한 후 추가적인 api 구현

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="697" alt="image" src="https://github.com/Journey-Together/Server/assets/102959791/1a97d5d2-bc3a-4d6f-b4c7-726115dd0df4">
<img width="673" alt="image" src="https://github.com/Journey-Together/Server/assets/102959791/5d9b7b1c-fcef-450c-9942-058a3d78e5de">
<img width="686" alt="image" src="https://github.com/Journey-Together/Server/assets/102959791/793b5bf5-39de-4716-80fe-e97ef378a46c">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
