### PR TITLE
[Fix/#81] 관광지 상세보기 api 수정

### DIFF
--- a/src/main/java/Journey/Together/domain/place/dto/response/PlaceDetailRes.java
+++ b/src/main/java/Journey/Together/domain/place/dto/response/PlaceDetailRes.java
@@ -17,13 +17,14 @@ public record PlaceDetailRes(
         Boolean isMark,
 
         Integer bookmarkNum,
+        Boolean isReview,
 
         List<Long> disability,
         List<SubDisability> subDisability,
         List<PlaceReviewDto> reviewList
 ) {
     static String cat = "관광지";
-    public static PlaceDetailRes of(Place place, Boolean isMark, Integer bookmarkNum, List<Long> disability, List<SubDisability> subDisability, List<PlaceReviewDto> reviewList){
+    public static PlaceDetailRes of(Place place, Boolean isMark, Integer bookmarkNum, List<Long> disability, List<SubDisability> subDisability, List<PlaceReviewDto> reviewList, Boolean isReview){
         if(place.getCategory().equals("B02"))
             cat = "숙소";
         else if (place.getCategory().equals("A05"))
@@ -34,6 +35,6 @@ public record PlaceDetailRes(
 
 
         return new PlaceDetailRes(place.getId(), place.getName(), place.getFirstImg(), place.getAddress(), cat, place.getOverview(), place.getMapX().toString(), place.getMapY().toString(), isMark,
-                bookmarkNum, disability, subDisability, reviewList);
+                bookmarkNum, isReview, disability, subDisability, reviewList);
     }
 }

--- a/src/main/java/Journey/Together/domain/place/service/PlaceService.java
+++ b/src/main/java/Journey/Together/domain/place/service/PlaceService.java
@@ -68,6 +68,7 @@ public class PlaceService {
     public PlaceDetailRes getPlaceDetail(Member member, Long placeId){
        // PlaceDetailRes of(Place place, Boolean isMark, Integer bookmarkNum, List<String> disability, List<String> subDisability, List< PlaceReviewDto > reviewList)
 
+        Boolean isReview = false;
         Place place = getPlace(placeId);
 
         List<PlaceBookmark> placeBookmarkList = placeBookmarkRepository.findAllByPlace(place);
@@ -78,8 +79,12 @@ public class PlaceService {
         List<SubDisability> subDisability = disabilityPlaceCategoryRepository.findDisabilitySubCategory(placeId).stream().map(SubDisability::of).toList();
 
         List<PlaceReview> placeReviews = placeReviewRepository.findAllByPlaceOrderByCreatedAtDesc(place);
+
+        if(placeReviewRepository.findPlaceReviewByMemberAndPlace(member,place) != null)
+            isReview = true;
+
         if(placeReviews.size()<0)
-            return PlaceDetailRes.of(place, isMark, placeBookmarkList.size(), disability, subDisability, null);
+            return PlaceDetailRes.of(place, isMark, placeBookmarkList.size(), disability, subDisability, null, isReview);
 
         List<PlaceReviewDto> reviewList = new ArrayList<>();
 
@@ -91,7 +96,7 @@ public class PlaceService {
                 reviewList.add(PlaceReviewDto.of(placeReview,s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile", placeReview.getPlace().getFirstImg()));
         });
 
-        return PlaceDetailRes.of(place, isMark, placeBookmarkList.size(), disability, subDisability, reviewList);
+        return PlaceDetailRes.of(place, isMark, placeBookmarkList.size(), disability, subDisability, reviewList, isReview);
 
     }
 

--- a/src/main/java/Journey/Together/domain/place/service/PlaceService.java
+++ b/src/main/java/Journey/Together/domain/place/service/PlaceService.java
@@ -93,7 +93,7 @@ public class PlaceService {
             if (placeReviewImgs.size() > 0) {
                 reviewList.add(PlaceReviewDto.of(placeReview, s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile",placeReviewImgs.get(0).getImgUrl()));
             } else
-                reviewList.add(PlaceReviewDto.of(placeReview,s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile", placeReview.getPlace().getFirstImg()));
+                reviewList.add(PlaceReviewDto.of(placeReview,s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile", null));
         });
 
         return PlaceDetailRes.of(place, isMark, placeBookmarkList.size(), disability, subDisability, reviewList, isReview);
@@ -120,7 +120,7 @@ public class PlaceService {
             if (placeReviewImgs.size() > 0) {
                 reviewList.add(PlaceReviewDto.of(placeReview, s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile",placeReviewImgs.get(0).getImgUrl()));
             } else
-                reviewList.add(PlaceReviewDto.of(placeReview,s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile", placeReview.getPlace().getFirstImg()));
+                reviewList.add(PlaceReviewDto.of(placeReview,s3Client.getUrl()+placeReview.getMember().getProfileUuid()+"/profile", null));
         });
 
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #81 

## 📋 구현 기능 명세
- [x] 관광지 상세보기 후기 작성여부 추가
- [x] 관광지 리뷰이미지 없으면 장소 대표이미지 대신 null

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
후기 작성여부는 게스트버전에는 추가하지않았고 
관광지 리뷰이미지는 게스트버전과 사용자버전 둘다 수정하였습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="798" alt="스크린샷 2024-07-04 오전 12 21 22" src="https://github.com/Journey-Together/Server/assets/92644651/5d3dddb0-d436-4862-a8b5-2d5c00bcac01">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- ~/v1/place/{placeId}
- ~/v1/place/guest/{placeId}
