### PR TITLE
[Fix/#83] 나의 여행지 후기 목록 수정

### DIFF
--- a/src/main/java/Journey/Together/domain/place/dto/request/UpdateReviewDto.java
+++ b/src/main/java/Journey/Together/domain/place/dto/request/UpdateReviewDto.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 public record UpdateReviewDto(
         @Nullable
-        @JsonFormat(pattern = "yyyy-MM-dd")
         Float grade,
         @Nullable
+        @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate date,
         @Nullable
         String content,

--- a/src/main/java/Journey/Together/domain/place/dto/response/MyPlaceReviewDto.java
+++ b/src/main/java/Journey/Together/domain/place/dto/response/MyPlaceReviewDto.java
@@ -2,14 +2,19 @@ package Journey.Together.domain.place.dto.response;
 
 import Journey.Together.domain.place.entity.PlaceReview;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public record MyPlaceReviewDto(
         Long reviewId,
-        String imgae,
-        String address,
+        Long placeId,
         String name,
-        Float grade
+        Float grade,
+        LocalDate date,
+        String content,
+        List<String> images
 ) {
-    public static MyPlaceReviewDto of(PlaceReview placeReview, String firstImg){
-        return new MyPlaceReviewDto(placeReview.getId(), firstImg, placeReview.getPlace().getAddress(), placeReview.getPlace().getName(), placeReview.getGrade());
+    public static MyPlaceReviewDto of(PlaceReview placeReview, List<String> images){
+        return new MyPlaceReviewDto(placeReview.getId(),placeReview.getPlace().getId(), placeReview.getPlace().getName(), placeReview.getGrade(), placeReview.getDate(), placeReview.getContent(), images);
     }
 }

--- a/src/main/java/Journey/Together/domain/place/dto/response/MyPlaceReviewRes.java
+++ b/src/main/java/Journey/Together/domain/place/dto/response/MyPlaceReviewRes.java
@@ -3,6 +3,8 @@ package Journey.Together.domain.place.dto.response;
 import java.util.List;
 
 public record MyPlaceReviewRes(
+
+        Long reviewNum,
         List<MyPlaceReviewDto> myPlaceReviewDtoList,
         Integer pageNo,
         Integer pageSize,

--- a/src/main/java/Journey/Together/domain/place/repository/PlaceReviewRepository.java
+++ b/src/main/java/Journey/Together/domain/place/repository/PlaceReviewRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview,Long> {
 
+
     List<PlaceReview> findAllByPlaceOrderByCreatedAtDesc(Place place);
     PlaceReview findPlaceReviewByMemberAndPlace(Member member, Place place);
     @Query("SELECT COUNT(pr) FROM PlaceReview pr WHERE pr.member = :member")

--- a/src/main/java/Journey/Together/domain/place/service/PlaceService.java
+++ b/src/main/java/Journey/Together/domain/place/service/PlaceService.java
@@ -199,9 +199,12 @@ public class PlaceService {
     public MyPlaceReviewRes getMyReviews(Member member, Pageable page){
         Pageable pageable = PageRequest.of(page.getPageNumber(), page.getPageSize(), Sort.by("createdAt").descending());
         Page<PlaceReview> placeReviewPage = placeReviewRepository.findAllByMemberOrderByCreatedAtDesc(member, pageable);
-        return new MyPlaceReviewRes(placeReviewPage.getContent().stream()
+
+        Long reviewNum = placeReviewRepository.countPlaceReviewByMember(member);
+
+        return new MyPlaceReviewRes(reviewNum,placeReviewPage.getContent().stream()
                 .map(this::getMyPlaceReview)
-                .toList(),placeReviewPage.getNumber(),placeReviewPage.getSize(),placeReviewPage.getTotalPages());
+                .toList(), placeReviewPage.getNumber(),placeReviewPage.getSize(),placeReviewPage.getTotalPages());
     }
 
     //나의 여행지 후기 삭제
@@ -277,8 +280,12 @@ public class PlaceService {
     }
 
     private MyPlaceReviewDto getMyPlaceReview(PlaceReview placeReview ){
-        List<PlaceReviewImg> imgList = placeReviewImgRepository.findAllByPlaceReview(placeReview);
-        return MyPlaceReviewDto.of(placeReview, imgList.get(0).getImgUrl());
+        List<String> list = placeReviewImgRepository.findAllByPlaceReview(placeReview)
+                .stream()
+                .map(PlaceReviewImg::getImgUrl)
+                .toList();
+
+        return MyPlaceReviewDto.of(placeReview, list);
 
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #83 

## 📋 구현 기능 명세
- [x] 나의 여행지 후기 목록 반환값 수정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
나의 여행지 후기 상세보기 화면이 없어지면서 새로운 화면에 맞게 반환 dto를 수정했습니다.
나의 여행지 후기 수정dto에 jsonFormat이 date에 걸려야하는데 grade로 잘못걸려있어 수정했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지



- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="839" alt="스크린샷 2024-07-04 오전 12 50 15" src="https://github.com/Journey-Together/Server/assets/92644651/a65041c7-27d0-40f8-b792-8fff4d4f0723">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- ~/v1/place/review/my
