### PR TITLE
[Feat/#102] 신고하기

### DIFF
--- a/src/main/java/Journey/Together/domain/member/service/MemberService.java
+++ b/src/main/java/Journey/Together/domain/member/service/MemberService.java
@@ -29,8 +29,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final InterestRepository interestRepository;
     private final S3Client s3Client;
-    private final PlaceReviewRepository placeReviewRepository;
     private final PlanReviewRepository planReviewRepository;
+    private final PlaceReviewRepository placeReviewRepository;
 
 
     public MyPageRes getMypage(Member member){

--- a/src/main/java/Journey/Together/domain/place/dto/response/MyPlaceReviewDto.java
+++ b/src/main/java/Journey/Together/domain/place/dto/response/MyPlaceReviewDto.java
@@ -12,9 +12,10 @@ public record MyPlaceReviewDto(
         Float grade,
         LocalDate date,
         String content,
-        List<String> images
+        List<String> images,
+        Boolean isReport
 ) {
     public static MyPlaceReviewDto of(PlaceReview placeReview, List<String> images){
-        return new MyPlaceReviewDto(placeReview.getId(),placeReview.getPlace().getId(), placeReview.getPlace().getName(), placeReview.getGrade(), placeReview.getDate(), placeReview.getContent(), images);
+        return new MyPlaceReviewDto(placeReview.getId(),placeReview.getPlace().getId(), placeReview.getPlace().getName(), placeReview.getGrade(), placeReview.getDate(), placeReview.getContent(), images, placeReview.getReport());
     }
 }

--- a/src/main/java/Journey/Together/domain/place/dto/response/MyReview.java
+++ b/src/main/java/Journey/Together/domain/place/dto/response/MyReview.java
@@ -12,9 +12,10 @@ public record MyReview(
         String address,
         Float grade,
         LocalDate date,
-        String content
+        String content,
+        Boolean isReport
 ) {
     static public MyReview of(PlaceReview placeReview, List<String> images){
-        return new MyReview(placeReview.getId(), images, placeReview.getPlace().getAddress(), placeReview.getPlace().getName(),placeReview.getGrade(), placeReview.getDate(), placeReview.getContent());
+        return new MyReview(placeReview.getId(), images, placeReview.getPlace().getAddress(), placeReview.getPlace().getName(),placeReview.getGrade(), placeReview.getDate(), placeReview.getContent(), placeReview.getReport());
     }
 }

--- a/src/main/java/Journey/Together/domain/place/entity/PlaceReview.java
+++ b/src/main/java/Journey/Together/domain/place/entity/PlaceReview.java
@@ -37,7 +37,7 @@ public class PlaceReview extends BaseTimeEntity {
 
     private LocalDate date;
 
-    private Boolean report;
+    private Boolean report = false;
 
 
     @Builder

--- a/src/main/java/Journey/Together/domain/place/entity/PlaceReview.java
+++ b/src/main/java/Journey/Together/domain/place/entity/PlaceReview.java
@@ -21,21 +21,23 @@ public class PlaceReview extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "place_review_id")
-    Long id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    Member member;
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id")
-    Place place;
+    private Place place;
 
-    Float grade;
+    private Float grade;
 
-    String content;
+    private String content;
 
-    LocalDate date;
+    private LocalDate date;
+
+    private Boolean report;
 
 
     @Builder

--- a/src/main/java/Journey/Together/domain/place/repository/PlaceReviewRepository.java
+++ b/src/main/java/Journey/Together/domain/place/repository/PlaceReviewRepository.java
@@ -15,13 +15,12 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview,Long> {
 
     PlaceReview findPlaceReviewById(Long id);
 
-    List<PlaceReview> findAllByPlaceOrderByCreatedAtDesc(Place place);
-    List<PlaceReview> findTop2ByPlaceOrderByCreatedAtDesc(Place place);
+    List<PlaceReview> findTop2ByPlaceAndReportIsTrueOrderByCreatedAtDesc(Place place);
     PlaceReview findPlaceReviewByMemberAndPlace(Member member, Place place);
     @Query("SELECT COUNT(pr) FROM PlaceReview pr WHERE pr.member = :member")
     Long countPlaceReviewByMember(@Param("member") Member member);
 
-    Page<PlaceReview> findAllByPlaceOrderByCreatedAtDesc(Place place, Pageable pageable);
+    Page<PlaceReview> findAllByPlaceAndReportIsTrueOrderByCreatedAtDesc(Place place, Pageable pageable);
 
     Page<PlaceReview> findAllByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
 

--- a/src/main/java/Journey/Together/domain/place/repository/PlaceReviewRepository.java
+++ b/src/main/java/Journey/Together/domain/place/repository/PlaceReviewRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview,Long> {
 
+    PlaceReview findPlaceReviewById(Long id);
 
     List<PlaceReview> findAllByPlaceOrderByCreatedAtDesc(Place place);
     List<PlaceReview> findTop2ByPlaceOrderByCreatedAtDesc(Place place);

--- a/src/main/java/Journey/Together/domain/place/service/PlaceService.java
+++ b/src/main/java/Journey/Together/domain/place/service/PlaceService.java
@@ -91,7 +91,7 @@ public class PlaceService {
         List<Long> disability = disabilityPlaceCategoryRepository.findDisabilityCategoryIds(placeId);
         List<SubDisability> subDisability = disabilityPlaceCategoryRepository.findDisabilitySubCategory(placeId).stream().map(SubDisability::of).toList();
 
-        List<PlaceReview> placeReviews = placeReviewRepository.findTop2ByPlaceOrderByCreatedAtDesc(place);
+        List<PlaceReview> placeReviews = placeReviewRepository.findTop2ByPlaceAndReportIsTrueOrderByCreatedAtDesc(place);
 
         if(placeReviewRepository.findPlaceReviewByMemberAndPlace(member,place) != null) {
             isReview = true;
@@ -135,7 +135,7 @@ public class PlaceService {
         List<Long> disability = disabilityPlaceCategoryRepository.findDisabilityCategoryIds(placeId);
         List<SubDisability> subDisability = disabilityPlaceCategoryRepository.findDisabilitySubCategory(placeId).stream().map(SubDisability::of).toList();
 
-        List<PlaceReview> placeReviews = placeReviewRepository.findTop2ByPlaceOrderByCreatedAtDesc(place);
+        List<PlaceReview> placeReviews = placeReviewRepository.findTop2ByPlaceAndReportIsTrueOrderByCreatedAtDesc(place);
         if(placeReviews.size()<0)
             return PlaceDetailGuestRes.of(place, placeBookmarkList.size(), disability, subDisability, null);
 
@@ -218,7 +218,7 @@ public class PlaceService {
         Place place = getPlace(placeId);
         List<PlaceReivewListDto> placeReviewList =new ArrayList<>();
         Pageable pageable = PageRequest.of(page.getPageNumber(), page.getPageSize(), Sort.by("createdAt").descending());
-        Page<PlaceReview> placeReviewPage = placeReviewRepository.findAllByPlaceOrderByCreatedAtDesc(place, pageable);
+        Page<PlaceReview> placeReviewPage = placeReviewRepository.findAllByPlaceAndReportIsTrueOrderByCreatedAtDesc(place, pageable);
         placeReviewPage.getContent().forEach(
                 placeReview -> {
                     if(Objects.equals(placeReview.getMember().getMemberId(), member.getMemberId()))
@@ -236,7 +236,7 @@ public class PlaceService {
         Place place = getPlace(placeId);
         List<PlaceReivewListDto> placeReviewList =new ArrayList<>();
         Pageable pageable = PageRequest.of(page.getPageNumber(), page.getPageSize(), Sort.by("createdAt").descending());
-        Page<PlaceReview> placeReviewPage = placeReviewRepository.findAllByPlaceOrderByCreatedAtDesc(place, pageable);
+        Page<PlaceReview> placeReviewPage = placeReviewRepository.findAllByPlaceAndReportIsTrueOrderByCreatedAtDesc(place, pageable);
         placeReviewPage.getContent().forEach(
                 placeReview -> {
                     placeReviewList.add(PlaceReivewListDto.of(placeReview,getImgUrls(placeReview),s3Client.getUrl(),false));

--- a/src/main/java/Journey/Together/domain/plan/entity/PlanReview.java
+++ b/src/main/java/Journey/Together/domain/plan/entity/PlanReview.java
@@ -34,6 +34,8 @@ public class PlanReview extends BaseTimeEntity {
     @JoinColumn(name = "plan_id")
     private Plan plan;
 
+    private Boolean report;
+
 
     @Builder
     public PlanReview(Member member,float grade, String content,Plan plan){

--- a/src/main/java/Journey/Together/domain/plan/entity/PlanReview.java
+++ b/src/main/java/Journey/Together/domain/plan/entity/PlanReview.java
@@ -34,7 +34,7 @@ public class PlanReview extends BaseTimeEntity {
     @JoinColumn(name = "plan_id")
     private Plan plan;
 
-    private Boolean report;
+    private Boolean report = false;
 
 
     @Builder
@@ -43,5 +43,9 @@ public class PlanReview extends BaseTimeEntity {
         this.grade = grade;
         this.content=content;
         this.plan=plan;
+    }
+
+    public void setReport(Boolean report) {
+        this.report = report;
     }
 }

--- a/src/main/java/Journey/Together/domain/plan/entity/PlanReviewImage.java
+++ b/src/main/java/Journey/Together/domain/plan/entity/PlanReviewImage.java
@@ -28,4 +28,5 @@ public class PlanReviewImage extends BaseTimeEntity {
         this.imageUrl=imageUrl;
         this.planReview= planReview;
     }
+
 }

--- a/src/main/java/Journey/Together/domain/plan/repository/PlanReviewImageRepository.java
+++ b/src/main/java/Journey/Together/domain/plan/repository/PlanReviewImageRepository.java
@@ -10,4 +10,6 @@ public interface PlanReviewImageRepository extends JpaRepository<PlanReviewImage
     List<PlanReviewImage> findAllByPlanReviewAndDeletedAtIsNull(PlanReview planReview);
     void deletePlanReviewImageByPlanReviewImageId(Long planReviewImageId);
     void deletePlanReviewImageByImageUrl(String imageUrl);
+
+    List<PlanReviewImage> findPlanReviewImageByPlanReview(PlanReview planReview);
 }

--- a/src/main/java/Journey/Together/domain/plan/repository/PlanReviewRepository.java
+++ b/src/main/java/Journey/Together/domain/plan/repository/PlanReviewRepository.java
@@ -11,6 +11,9 @@ import org.springframework.data.repository.query.Param;
 public interface PlanReviewRepository extends JpaRepository<PlanReview,Long> {
     boolean existsAllByPlan(Plan plan);
     PlanReview findPlanReviewByPlan(Plan plan);
+
+
+    PlanReview findPlanReviewByPlanReviewId(Long id);
     PlanReview findPlanReviewByPlanAndDeletedAtIsNull(Plan plan);
     @Query("SELECT COUNT(pr) FROM PlanReview pr WHERE pr.member = :member")
     Long countPlanReviewByMember(@Param("member") Member member);

--- a/src/main/java/Journey/Together/domain/report/controller/ReportController.java
+++ b/src/main/java/Journey/Together/domain/report/controller/ReportController.java
@@ -1,0 +1,26 @@
+package Journey.Together.domain.report.controller;
+
+import Journey.Together.domain.report.dto.ReportReq;
+import Journey.Together.domain.report.enumerate.ReviewType;
+import Journey.Together.domain.report.service.ReportService;
+import Journey.Together.global.common.ApiResponse;
+import Journey.Together.global.exception.Success;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/report")
+@Tag(name = "Report", description = "신고하기 관련 API")
+public class ReportController {
+    private final ReportService reportService;
+
+    @PostMapping()
+    public ApiResponse<?> createReport(@RequestBody ReportReq reportReq,
+                                       @RequestParam String reviewType){
+        reportService.createReport(reportReq, reviewType);
+        return ApiResponse.success(Success.CREATE_RERORT_SUCCESS);
+    }
+
+}

--- a/src/main/java/Journey/Together/domain/report/controller/ReportController.java
+++ b/src/main/java/Journey/Together/domain/report/controller/ReportController.java
@@ -1,12 +1,17 @@
 package Journey.Together.domain.report.controller;
 
 import Journey.Together.domain.report.dto.ReportReq;
+import Journey.Together.domain.report.dto.ReportRes;
 import Journey.Together.domain.report.enumerate.ReviewType;
 import Journey.Together.domain.report.service.ReportService;
 import Journey.Together.global.common.ApiResponse;
 import Journey.Together.global.exception.Success;
+import Journey.Together.global.security.PrincipalDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,6 +26,18 @@ public class ReportController {
                                        @RequestParam String reviewType){
         reportService.createReport(reportReq, reviewType);
         return ApiResponse.success(Success.CREATE_RERORT_SUCCESS);
+    }
+
+
+    @GetMapping()
+    public ApiResponse<ReportRes> getReports(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                             @RequestParam(required = false) Boolean approval,
+                                             @RequestParam(required = false) String reason,
+                                             @RequestParam(required = false) String reviewType,
+                                             @PageableDefault(size = 10,page = 0) Pageable pageable
+                                     ){
+        return ApiResponse.success(Success.CREATE_RERORT_SUCCESS,
+                reportService.getReports(principalDetails.getMember(), approval, reason, reviewType, pageable));
     }
 
 }

--- a/src/main/java/Journey/Together/domain/report/controller/ReportController.java
+++ b/src/main/java/Journey/Together/domain/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package Journey.Together.domain.report.controller;
 
+import Journey.Together.domain.report.dto.ApprovalDto;
 import Journey.Together.domain.report.dto.ReportReq;
 import Journey.Together.domain.report.dto.ReportRes;
 import Journey.Together.domain.report.enumerate.ReviewType;
@@ -38,6 +39,13 @@ public class ReportController {
                                      ){
         return ApiResponse.success(Success.CREATE_RERORT_SUCCESS,
                 reportService.getReports(principalDetails.getMember(), approval, reason, reviewType, pageable));
+    }
+
+    @PatchMapping()
+    public ApiResponse<?> setAprrovalStatus(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                            @RequestBody ApprovalDto approvalDto){
+            reportService.setApprovalStatus(principalDetails.getMember(), approvalDto);
+        return ApiResponse.success(Success.UPDATE_APPROVAL_SUCCESS);
     }
 
 }

--- a/src/main/java/Journey/Together/domain/report/dto/ApprovalDto.java
+++ b/src/main/java/Journey/Together/domain/report/dto/ApprovalDto.java
@@ -1,0 +1,7 @@
+package Journey.Together.domain.report.dto;
+
+public record ApprovalDto(
+        Long reportId,
+        Boolean approval
+) {
+}

--- a/src/main/java/Journey/Together/domain/report/dto/FilterReport.java
+++ b/src/main/java/Journey/Together/domain/report/dto/FilterReport.java
@@ -1,0 +1,11 @@
+package Journey.Together.domain.report.dto;
+
+import Journey.Together.domain.report.entity.Report;
+
+import java.util.List;
+
+public record FilterReport(
+        List<Report> reports,
+        Long size
+) {
+}

--- a/src/main/java/Journey/Together/domain/report/dto/ReportDto.java
+++ b/src/main/java/Journey/Together/domain/report/dto/ReportDto.java
@@ -1,0 +1,19 @@
+package Journey.Together.domain.report.dto;
+
+import Journey.Together.domain.report.entity.Report;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReportDto (
+        Long reportId,
+        String reason,
+        String description,
+        Boolean approval,
+        LocalDateTime reportTime,
+        ReviewDto reviewDto){
+    public static ReportDto of(Report report, ReviewDto reviewDto){
+        return new ReportDto(report.getId(), report.getReason(), report.getDescription(),
+                report.getApproval(), report.getCreatedAt(), reviewDto);
+    }
+}

--- a/src/main/java/Journey/Together/domain/report/dto/ReportReq.java
+++ b/src/main/java/Journey/Together/domain/report/dto/ReportReq.java
@@ -1,0 +1,14 @@
+package Journey.Together.domain.report.dto;
+
+import Journey.Together.domain.report.enumerate.ReviewType;
+import jakarta.validation.constraints.NotNull;
+
+
+public record ReportReq (
+       @NotNull Long review_id,
+       @NotNull String reason,
+       String description
+
+){
+
+}

--- a/src/main/java/Journey/Together/domain/report/dto/ReportRes.java
+++ b/src/main/java/Journey/Together/domain/report/dto/ReportRes.java
@@ -1,0 +1,12 @@
+package Journey.Together.domain.report.dto;
+
+import java.util.List;
+
+public record ReportRes(
+    Long reportNum,
+    List<ReportDto> reportResultList,
+    Integer pageNo,
+    Integer pageSize
+){
+
+}

--- a/src/main/java/Journey/Together/domain/report/dto/ReviewDto.java
+++ b/src/main/java/Journey/Together/domain/report/dto/ReviewDto.java
@@ -1,0 +1,16 @@
+package Journey.Together.domain.report.dto;
+
+import Journey.Together.domain.report.enumerate.ReviewType;
+
+import java.util.List;
+
+public record ReviewDto(
+        Long reviewId,
+        Long memberId,
+        String memberName,
+        ReviewType reviewType,
+        String content,
+        List<String> imgList
+
+) {}
+

--- a/src/main/java/Journey/Together/domain/report/entity/Report.java
+++ b/src/main/java/Journey/Together/domain/report/entity/Report.java
@@ -38,4 +38,8 @@ public class Report extends BaseTimeEntity {
         this.reviewType=reviewType;
     }
 
+    public void setApproval(Boolean approval){
+        this.approval = approval;
+    }
+
 }

--- a/src/main/java/Journey/Together/domain/report/entity/Report.java
+++ b/src/main/java/Journey/Together/domain/report/entity/Report.java
@@ -5,6 +5,7 @@ import Journey.Together.domain.report.enumerate.ReviewType;
 import Journey.Together.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,5 +29,13 @@ public class Report extends BaseTimeEntity {
     private ReviewType reviewType;
 
     private Boolean approval;
+
+    @Builder
+    public Report(Long review_id, String reason, String description, ReviewType reviewType){
+        this.review_id=review_id;
+        this.reason=reason;
+        this.description=description;
+        this.reviewType=reviewType;
+    }
 
 }

--- a/src/main/java/Journey/Together/domain/report/entity/Report.java
+++ b/src/main/java/Journey/Together/domain/report/entity/Report.java
@@ -1,0 +1,32 @@
+package Journey.Together.domain.report.entity;
+
+import Journey.Together.domain.member.entity.Member;
+import Journey.Together.domain.report.enumerate.ReviewType;
+import Journey.Together.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "report")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long review_id;
+
+    private String reason;
+
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private ReviewType reviewType;
+
+    private Boolean approval;
+
+}

--- a/src/main/java/Journey/Together/domain/report/enumerate/ReviewType.java
+++ b/src/main/java/Journey/Together/domain/report/enumerate/ReviewType.java
@@ -1,0 +1,6 @@
+package Journey.Together.domain.report.enumerate;
+
+public enum ReviewType {
+    PlaceReview,
+    PlanReview
+}

--- a/src/main/java/Journey/Together/domain/report/repository/ReportRepository.java
+++ b/src/main/java/Journey/Together/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package Journey.Together.domain.report.repository;
+
+import Journey.Together.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report,Long> {
+}

--- a/src/main/java/Journey/Together/domain/report/repository/ReportRepository.java
+++ b/src/main/java/Journey/Together/domain/report/repository/ReportRepository.java
@@ -3,5 +3,5 @@ package Journey.Together.domain.report.repository;
 import Journey.Together.domain.report.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<Report,Long> {
+public interface ReportRepository extends JpaRepository<Report,Long>, ReportRepositoryCustom {
 }

--- a/src/main/java/Journey/Together/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/Journey/Together/domain/report/repository/ReportRepositoryCustom.java
@@ -1,0 +1,12 @@
+package Journey.Together.domain.report.repository;
+
+import Journey.Together.domain.report.dto.FilterReport;
+import Journey.Together.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface ReportRepositoryCustom {
+    FilterReport getReportList(Boolean approval, String reason, String reviewType, Pageable pageable);
+}

--- a/src/main/java/Journey/Together/domain/report/repository/ReportRepositoryImpl.java
+++ b/src/main/java/Journey/Together/domain/report/repository/ReportRepositoryImpl.java
@@ -1,0 +1,65 @@
+package Journey.Together.domain.report.repository;
+
+import Journey.Together.domain.place.dto.response.SearchPlace;
+import Journey.Together.domain.report.dto.FilterReport;
+import Journey.Together.domain.report.entity.QReport;
+import Journey.Together.domain.report.entity.Report;
+import Journey.Together.domain.report.enumerate.ReviewType;
+import Journey.Together.domain.report.service.ReportService;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+import static Journey.Together.domain.place.entity.QPlace.place;
+import static Journey.Together.domain.report.entity.QReport.report;
+
+public class ReportRepositoryImpl  implements ReportRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    public ReportRepositoryImpl(EntityManager em){
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public FilterReport getReportList(Boolean approval, String reason,
+                                      String reviewType, Pageable pageable) {
+        List<Report> reports = queryFactory
+                .selectDistinct(report)
+                .from(report)
+                .where(approvalEq(approval),reasonEq(reason), reviewTypeEq(reviewType))
+                .orderBy(report.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(report.countDistinct())
+                .from(report)
+                .where(approvalEq(approval),reasonEq(reason), reviewTypeEq(reviewType))
+                .orderBy(report.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchOne();
+
+        return new FilterReport(reports,total);
+    }
+
+    private BooleanExpression reviewTypeEq(String reviewType) {
+        return reviewType != null ?  report.reviewType.eq(ReviewType.valueOf(reviewType)) : null;
+    }
+
+    private BooleanExpression reasonEq(String reason) {
+        return reason != null ?  report.reason.eq(reason) : null;
+    }
+
+    private BooleanExpression approvalEq(Boolean approval) {
+        return approval != null ?  report.approval.eq(approval) : null;
+    }
+
+}

--- a/src/main/java/Journey/Together/domain/report/service/ReportService.java
+++ b/src/main/java/Journey/Together/domain/report/service/ReportService.java
@@ -1,0 +1,63 @@
+package Journey.Together.domain.report.service;
+
+import Journey.Together.domain.place.entity.PlaceReview;
+import Journey.Together.domain.place.repository.PlaceReviewRepository;
+import Journey.Together.domain.plan.entity.PlanReview;
+import Journey.Together.domain.plan.repository.PlanReviewRepository;
+import Journey.Together.domain.report.dto.ReportReq;
+import Journey.Together.domain.report.entity.Report;
+import Journey.Together.domain.report.enumerate.ReviewType;
+import Journey.Together.domain.report.repository.ReportRepository;
+import Journey.Together.global.exception.ApplicationException;
+import Journey.Together.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final ReportRepository reportRepository;
+    private final PlanReviewRepository planReviewRepository;
+    private final PlaceReviewRepository placeReviewRepository;
+
+    @Transactional
+    public void createReport(ReportReq reportReq, String reviewType){
+        if(Objects.equals(reportReq.reason(), "기타") && reportReq.description()==null){
+            throw new ApplicationException(ErrorCode.NOT_FOUND_DESCRIPTION_EXCEPTION);
+        }
+
+        if(reviewType.equals("PlanReview")){
+            PlanReview planReview = planReviewRepository.findById(reportReq.review_id()).orElseThrow(
+                    () -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
+            );
+            planReview.setReport(true);
+            reportRepository.save(reportBuilder(reportReq,ReviewType.PlanReview));
+
+        }else if(reviewType.equals("PlaceReview")){
+            PlaceReview placeReview = placeReviewRepository.findById(reportReq.review_id()).orElseThrow(
+                    () -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
+            );
+            placeReview.setReport(true);
+            reportRepository.save(reportBuilder(reportReq,ReviewType.PlaceReview));
+        }else {
+            throw new ApplicationException(ErrorCode.REVIEW_TYPE_EXCEPTION);
+        }
+
+    }
+
+    public Report reportBuilder(ReportReq reportReq,ReviewType reviewType){
+        if(reportReq.description() != null){
+            return Report.builder().review_id(reportReq.review_id())
+                    .reason(reportReq.reason())
+                    .description(reportReq.description())
+                    .reviewType(reviewType).build();
+        }else{
+            return Report.builder().review_id(reportReq.review_id())
+                    .reason(reportReq.reason())
+                    .reviewType(reviewType).build();
+        }
+    }
+}

--- a/src/main/java/Journey/Together/domain/report/service/ReportService.java
+++ b/src/main/java/Journey/Together/domain/report/service/ReportService.java
@@ -45,14 +45,12 @@ public class ReportService {
             PlanReview planReview = planReviewRepository.findById(reportReq.review_id()).orElseThrow(
                     () -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
             );
-            planReview.setReport(true);
             reportRepository.save(reportBuilder(reportReq,ReviewType.PlanReview));
 
         }else if(reviewType.equals("PlaceReview")){
             PlaceReview placeReview = placeReviewRepository.findById(reportReq.review_id()).orElseThrow(
                     () -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
             );
-            placeReview.setReport(true);
             reportRepository.save(reportBuilder(reportReq,ReviewType.PlaceReview));
         }else {
             throw new ApplicationException(ErrorCode.REVIEW_TYPE_EXCEPTION);
@@ -100,6 +98,34 @@ public class ReportService {
         }
         else{
             throw new ApplicationException(ErrorCode.INTERNAL_SERVER_EXCEPTION);
+        }
+    }
+
+    @Transactional
+    public void setApprovalStatus(Member member, ApprovalDto approvalDto) {
+        if(!member.getMemberType().equals(MemberType.ADMIN)){
+            throw new ApplicationException(ErrorCode.WRONG_ACCESS_EXCEPTION);
+        }
+
+        Report report = reportRepository.findById(approvalDto.reportId()).orElseThrow(
+                () -> new ApplicationException(ErrorCode.NOT_FOUND_REPORT_EXCEPTION)
+        );
+
+        report.setApproval(approvalDto.approval());
+
+        if(report.getReviewType() == ReviewType.PlanReview){
+            PlanReview planReview = planReviewRepository.findById(report.getReview_id()).orElseThrow(
+                    () -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
+            );
+            planReview.setReport(approvalDto.approval());
+
+        }else if(report.getReviewType() == ReviewType.PlaceReview){
+            PlaceReview placeReview = placeReviewRepository.findById(report.getReview_id()).orElseThrow(
+                    () -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
+            );
+            placeReview.setReport(approvalDto.approval());
+        }else {
+            throw new ApplicationException(ErrorCode.REVIEW_TYPE_EXCEPTION);
         }
     }
 }

--- a/src/main/java/Journey/Together/global/config/SecurityConfig.java
+++ b/src/main/java/Journey/Together/global/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                         .requestMatchers("/v1/place/search/**").permitAll()
                         .requestMatchers("/v1/place/search/map").permitAll()
                         .requestMatchers("/v1/place/guest/**").permitAll()
+                        .requestMatchers("/v1/report/**").permitAll()
 
                         // 메인 페이지, 공고 페이지 등에 한해 인증 정보 없이 접근 가능 (추후 추가)
                         // 이외의 모든 요청은 인증 정보 필요

--- a/src/main/java/Journey/Together/global/exception/ErrorCode.java
+++ b/src/main/java/Journey/Together/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     OVER_APPLY_EXCEPTION(HttpStatus.NOT_FOUND,4007,"지원 파트 정원이 찼습니다."),
     INVALID_MAP_EXCEPTION(HttpStatus.NOT_FOUND,4008,"모든 좌표값이 요청되지 않았습니다."),
     NOT_FOUND_PLACE_REVIEW_EXCEPTION(HttpStatus.NOT_FOUND,4009,"존재하지 않는 여행지리뷰입니다."),
+    NOT_FOUND_REPORT_EXCEPTION(HttpStatus.NOT_FOUND,4010,"존재하지 않는 신고입니다."),
 
     //5000: Post Error
     NOT_POST_EXCEPTION(HttpStatus.BAD_REQUEST,5000,"공고를 더 이상 생성할 수 없습니다"),

--- a/src/main/java/Journey/Together/global/exception/ErrorCode.java
+++ b/src/main/java/Journey/Together/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     WRONG_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3002, "유효하지 않은 토큰입니다."),
     LOGOUT_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3003, "로그아웃된 토큰입니다"),
     WRONG_TOKEN(HttpStatus.UNAUTHORIZED, 3004, "유효하지 않은 토큰입니다."),
+    WRONG_ACCESS_EXCEPTION(HttpStatus.BAD_REQUEST, 3005, "관리자만 접근 가능합니다."),
 
 
     //4000: Apply Error

--- a/src/main/java/Journey/Together/global/exception/ErrorCode.java
+++ b/src/main/java/Journey/Together/global/exception/ErrorCode.java
@@ -49,7 +49,9 @@ public enum ErrorCode {
     NOT_FOUNT_SCRAP_EXCEPTION(HttpStatus.NOT_FOUND,5002,"스크랩 정보가 존재하지 않습니다."),
     ALREADY_FINISH_EXCEPTION(HttpStatus.BAD_REQUEST, 5003, "이미 모집 기간이 마감된 공고입니다."),
     ILLEGAL_POST_EXCEPTION(HttpStatus.BAD_REQUEST, 5004, "파트별 인원수가 전체 인원수와 일치하지 않습니다."),
-    NOT_ADD_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST,5005,"예상치 못한 에러가 발생하여 이미지 추가가 되지 않습니다.");
+    NOT_ADD_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST,5005,"예상치 못한 에러가 발생하여 이미지 추가가 되지 않습니다."),
+    REVIEW_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST,5006,"올바르지 않은 리뷰 타입입니다."),
+    NOT_FOUND_DESCRIPTION_EXCEPTION(HttpStatus.BAD_REQUEST,5007,"기타 사유 선택 시, 상세한 신고 사유는 필수입니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/Journey/Together/global/exception/Success.java
+++ b/src/main/java/Journey/Together/global/exception/Success.java
@@ -61,6 +61,7 @@ public enum Success {
 	UPDATE_PLAN_SUCCESS(HttpStatus.CREATED, "일정 수정이 완료 되었습니다."),
 
 	UPDATE_ISR성AD_SUCCESS(HttpStatus.OK, "열람여부 수정 완료"),
+	UPDATE_APPROVAL_SUCCESS(HttpStatus.OK, "승인 상태 수정 완료"),
 	UPDATE_CATEGORY_TITLE_SUCCESS(HttpStatus.OK, "카테고리 수정 완료"),
 	UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정 완료"),
 	CHANGE_BOOKMARK_SUCCESS(HttpStatus.OK, "북마크 상태 수정 완료"),

--- a/src/main/java/Journey/Together/global/exception/Success.java
+++ b/src/main/java/Journey/Together/global/exception/Success.java
@@ -36,6 +36,7 @@ public enum Success {
 	GET_PLAN_SUCCESS(HttpStatus.OK, "내 일정 조회 성공"),
 	GET_SITES_SUCCESS(HttpStatus.OK, "추천 사이트 조회 성공"),
 	GET_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 조회 성공"),
+	GET_REPORT_LIST_SUCCESS(HttpStatus.OK, "신고목록 조회 성공"),
 
 	GET_CATEORIES_SUCCESS(HttpStatus.OK, "전체 카테고리 조회 성공"),
 	GET_CATEORY_SUCCESS(HttpStatus.OK, "세부 카테고리 조회 성공"),

--- a/src/main/java/Journey/Together/global/exception/Success.java
+++ b/src/main/java/Journey/Together/global/exception/Success.java
@@ -15,6 +15,7 @@ public enum Success {
 	CREATE_CATEGORY_SUCCESS(HttpStatus.CREATED, "새 카테고리 추가 성공"),
 	CREATE_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰 생성 성공"),
 	CREATE_PLACE_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰 작성 성공"),
+	CREATE_RERORT_SUCCESS(HttpStatus.CREATED, "신고 성공"),
 
 	/**
 	 * 200 OK


### PR DESCRIPTION
## 🚩 관련 이슈
- close #102 

## 📋 구현 기능 명세
- [x]  신고 엔티티 설계
- [x]  신고 요청 api
- [x]  신고 목록 api
- [x]  승인/비승인 요청하는 api
- [x]  신고되었을때 처리


## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
신고하기 기능 추가를 위해 신고(report) 엔티티를 추가하였습니다. 
(간단히 필드들만 나타내면 아래와 같습니다.)
``` java
public class Report extends BaseTimeEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    private Long review_id;

    private String reason;

    private String description;

    @Enumerated(EnumType.STRING)
    private ReviewType reviewType;

    private Boolean approval;

```
- 어떤 부분에 리뷰어가 집중해야 하는지
지금 PlaceReview, PlanReview 모두 ` Boolean report ` 값을 추가해서 신고승인이 됐는지 여부를 파악하고있습니다.
(null -> 기본값, true-> 신고 승인, false -> 신고 비승인)
전체 placeReview에 대해서 보여주는 요청은 report가 true인것을 필터링하여 내려주었고 
나의 리뷰를 보는 api에서는 필터링하지않고 따로 Reponse에 isReport값을 추가하여 신고승인이 되었는지 여부를 알려주었습니다.
**PlanReview에는 어떤것이 전체이고 나의 것을 보는 것인지 헷갈려 아무 처리 못했는데 그것만 해주시면 감사하겠습니당 ㅎㅎ**

- 개발하면서 어떤 점이 궁금했는지
리뷰가 두개인데 review_id를 하나로 합칠려고하니 항상 어떤 로직을 수행할때 reviewType에 따라 검증하고 따로 수행해야하는 로직이 발생했는데 이게 맞는지 잘 모르겠습니다....

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- {baseurl}/v1/report
