### PR TITLE
[Feat/#91] 네이버 회원탈퇴

### DIFF
--- a/src/main/java/Journey/Together/domain/member/controller/AuthController.java
+++ b/src/main/java/Journey/Together/domain/member/controller/AuthController.java
@@ -1,5 +1,6 @@
 package Journey.Together.domain.member.controller;
 
+import Journey.Together.domain.member.dto.LoginReq;
 import Journey.Together.domain.member.dto.LoginRes;
 import Journey.Together.domain.member.service.AuthService;
 import Journey.Together.global.common.ApiResponse;
@@ -30,8 +31,9 @@ public class AuthController {
     @Operation(summary = "로그인 API")
     @PostMapping("/sign-in")
     public ApiResponse<LoginRes> signIn(@RequestHeader("Authorization") String token,
-                                        @RequestParam String type) throws IOException {
-        return ApiResponse.success(Success.LOGIN_SUCCESS,authService.signIn(token,type));
+                                        @RequestParam String type,
+                                        @RequestBody LoginReq loginReq) throws IOException {
+        return ApiResponse.success(Success.LOGIN_SUCCESS,authService.signIn(token,type,loginReq));
     }
 
     @Operation(summary = "로그아웃 API", description = "로그아웃된 JWT 블랙리스트 등록")

--- a/src/main/java/Journey/Together/domain/member/dto/LoginReq.java
+++ b/src/main/java/Journey/Together/domain/member/dto/LoginReq.java
@@ -1,0 +1,5 @@
+package Journey.Together.domain.member.dto;
+public record LoginReq(
+        String refreshToken
+) {
+}

--- a/src/main/java/Journey/Together/domain/member/entity/Interest.java
+++ b/src/main/java/Journey/Together/domain/member/entity/Interest.java
@@ -4,6 +4,8 @@ import Journey.Together.domain.member.dto.InterestDto;
 import Journey.Together.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Setter
 @Getter
@@ -18,6 +20,7 @@ public class Interest extends BaseTimeEntity {
     private Long interestId;
 
     @ManyToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/Journey/Together/domain/member/entity/Interest.java
+++ b/src/main/java/Journey/Together/domain/member/entity/Interest.java
@@ -19,7 +19,7 @@ public class Interest extends BaseTimeEntity {
     @Column(name = "interest_id", columnDefinition = "bigint")
     private Long interestId;
 
-    @ManyToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
+    @OneToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/Journey/Together/domain/member/service/AuthService.java
+++ b/src/main/java/Journey/Together/domain/member/service/AuthService.java
@@ -1,5 +1,6 @@
 package Journey.Together.domain.member.service;
 
+import Journey.Together.domain.member.dto.LoginReq;
 import Journey.Together.domain.member.dto.LoginRes;
 import Journey.Together.domain.member.entity.Interest;
 import Journey.Together.domain.member.entity.Member;
@@ -52,7 +53,7 @@ public class AuthService {
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Transactional
-    public LoginRes signIn(String token, String type) throws IOException {
+    public LoginRes signIn(String token, String type, LoginReq loginReq) throws IOException {
         Member member = null;
         TokenDto tokenDto = null;
 
@@ -124,7 +125,7 @@ public class AuthService {
             }
 
             tokenDto = tokenProvider.createToken(member);
-//            member.setRefreshToken(tokenDto.refreshToken());
+            member.setRefreshToken(loginReq.refreshToken());
         }
         return LoginRes.of(member, tokenDto);
     }

--- a/src/main/java/Journey/Together/global/exception/ErrorCode.java
+++ b/src/main/java/Journey/Together/global/exception/ErrorCode.java
@@ -53,7 +53,9 @@ public enum ErrorCode {
     ILLEGAL_POST_EXCEPTION(HttpStatus.BAD_REQUEST, 5004, "파트별 인원수가 전체 인원수와 일치하지 않습니다."),
     NOT_ADD_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST,5005,"예상치 못한 에러가 발생하여 이미지 추가가 되지 않습니다."),
     REVIEW_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST,5006,"올바르지 않은 리뷰 타입입니다."),
-    NOT_FOUND_DESCRIPTION_EXCEPTION(HttpStatus.BAD_REQUEST,5007,"기타 사유 선택 시, 상세한 신고 사유는 필수입니다.");
+    NOT_FOUND_DESCRIPTION_EXCEPTION(HttpStatus.BAD_REQUEST,5007,"기타 사유 선택 시, 상세한 신고 사유는 필수입니다."),
+    NAVER_REFRESH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,5008,"네이버 토큰 재발급 에러."),
+    NAVER_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,5009,"네이버 탈퇴 에러");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/Journey/Together/global/security/naver/dto/NaverDeleteResponse.java
+++ b/src/main/java/Journey/Together/global/security/naver/dto/NaverDeleteResponse.java
@@ -8,15 +8,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class NaverTokenResponse {
+public class NaverDeleteResponse {
     @JsonProperty("access_token")
     private String accessToken;
-    @JsonProperty("refresh_token")
-    private String refreshToken;
-    @JsonProperty("token_type")
-    private String tokenType;
-    @JsonProperty("expires_in")
-    private String expiresIn;
+    @JsonProperty("result")
+    private String result;
     @JsonProperty("error")
     private String error;
     @JsonProperty("error_description")

--- a/src/main/java/Journey/Together/global/security/naver/dto/NaverProperties.java
+++ b/src/main/java/Journey/Together/global/security/naver/dto/NaverProperties.java
@@ -1,24 +1,52 @@
 package Journey.Together.global.security.naver.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@Data
 @Configuration
+@Getter
 @ConfigurationProperties(prefix = "naver")
 public class NaverProperties {
-    private String requestTokenUri;
-    private String clientId;
-    private String clientSecret;
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
 
-    public String getRequestURL(String code) {
-        return UriComponentsBuilder.fromHttpUrl(requestTokenUri)
-                .queryParam("grant_type", "authorization_code")
-                .queryParam("client_id", clientId)
-                .queryParam("client_secret", clientSecret)
-                .queryParam("code", code)
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.authorization-grant-type}")
+    private String naverGrantType;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String naverRedirectUri;
+
+    @Value("${spring.security.oauth2.client.provider.naver.token-uri}")
+    private String naverTokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.naver.user-info-uri}")
+    private String naverUserInfoUri;
+
+    // 새로운 액세스 토큰을 요청하기 위한 URI 생성
+    public String refreshTokenUri(String refreshToken) {
+        return UriComponentsBuilder.fromHttpUrl("https://nid.naver.com/oauth2.0/token")
+                .queryParam("grant_type", "refresh_token")
+                .queryParam("client_id", naverClientId)
+                .queryParam("client_secret", naverClientSecret)
+                .queryParam("refresh_token", refreshToken)
                 .toUriString();
     }
+
+    public String delete(String accessToken) {
+        return UriComponentsBuilder.fromHttpUrl("https://nid.naver.com/oauth2.0/token")
+                .queryParam("grant_type", "delete")
+                .queryParam("client_id", naverClientId)
+                .queryParam("client_secret", naverClientSecret)
+                .queryParam("access_token", accessToken)
+                .queryParam("service_provider", "NAVER")
+                .toUriString();
+    }
+
+
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #91 

## 📋 구현 기능 명세
- [x] 네이버 회원탈퇴
- [x] 네이버 리프레시 토큰 재갱신
- [x] 로그인 requestBody 추가

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
현재 member를 삭제하면 interest 외래키 오류가나서 
```
    @ManyToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
    @OnDelete(action = OnDeleteAction.CASCADE)
    @JoinColumn(name = "member_id")
    private Member member;
```
OnDelete 에노테이션으로 CASCADE 설정했습니다.
또한 refreshToken을 받아와야해서 로그인 api에 requestBody로 loginReq 객체 추가하여 받도록 설정하였습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지
Interest가 한 사용자에서 여러개 나오는건가요?
@ ManyToOne으로 되어있어 궁금했습니다.

## 📸 결과물 스크린샷
<img width="1086" alt="스크린샷 2024-09-21 오후 12 53 02" src="https://github.com/user-attachments/assets/d735403a-72e3-4f78-be2f-6607801dcfd9">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/v1/auth/withdrawal
