### PR TITLE
[Feat/#113] JWT 토큰 인증 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'mysql:mysql-connector-java:8.0.32'
+	implementation 'org.projectlombok:lombok:1.18.26'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/Journey/Together/domain/bookbark/controller/BookmarkController.java
+++ b/src/main/java/Journey/Together/domain/bookbark/controller/BookmarkController.java
@@ -26,39 +26,39 @@ public class BookmarkController {
     @GetMapping("/names")
     public ApiResponse<List<PlaceBookmarkDto>> getBookmarkPlaceNames(
             @AuthenticationPrincipal PrincipalDetails principalDetails){
-        return ApiResponse.success(Success.GET_BOOKMARK_PLACE_NAMES_SUCCESS, bookmarkService.getBookmarkPlaceNames(principalDetails.getMember()));
+        return ApiResponse.success(Success.GET_BOOKMARK_PLACE_NAMES_SUCCESS, bookmarkService.getBookmarkPlaceNames(principalDetails.getMemberId()));
     }
     @GetMapping("/place")
     public ApiResponse<List<PlaceBookmarkRes>> getPlaceBookmarks(
             @AuthenticationPrincipal PrincipalDetails principalDetails){
-        return ApiResponse.success(Success.GET_BOOKMARK_PLACES_SUCCESS, bookmarkService.getPlaceBookmarks(principalDetails.getMember()));
+        return ApiResponse.success(Success.GET_BOOKMARK_PLACES_SUCCESS, bookmarkService.getPlaceBookmarks(principalDetails.getMemberId()));
     }
 
     @GetMapping("/plan")
     public ApiResponse<List<PlanBookmarkRes>> getPlanBookmarks(
             @AuthenticationPrincipal PrincipalDetails principalDetails){
-        return ApiResponse.success(Success.GET_BOOKMARK_PLAN_SUCCESS, bookmarkService.getPlanBookmarks(principalDetails.getMember()));
+        return ApiResponse.success(Success.GET_BOOKMARK_PLAN_SUCCESS, bookmarkService.getPlanBookmarks(principalDetails.getMemberId()));
     }
 
 
     @PatchMapping("/place/{placeId}")
     public ApiResponse<?> updatePlaceBookmark(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long placeId){
-        bookmarkService.placeBookmark(principalDetails.getMember(), placeId);
+        bookmarkService.placeBookmark(principalDetails.getMemberId(), placeId);
         return ApiResponse.success(Success.CHANGE_BOOKMARK_SUCCESS);
     }
 
     @PatchMapping("/plan/{planId}")
     public ApiResponse<?> updatePlanBookmark(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long planId){
-        bookmarkService.planBookmark(principalDetails.getMember(), planId);
+        bookmarkService.planBookmark(principalDetails.getMemberId(), planId);
         return ApiResponse.success(Success.CHANGE_BOOKMARK_SUCCESS);
     }
 
     @GetMapping("/plan/{planId}")
     public ApiResponse<PlanBookMarkStateRes> findPlanBookmark(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long planId){
-        return ApiResponse.success(Success.GET_BOOKMARK_PLAN_STATE_SUCCESS,bookmarkService.findPlanBookmark(principalDetails.getMember(), planId));
+        return ApiResponse.success(Success.GET_BOOKMARK_PLAN_STATE_SUCCESS,bookmarkService.findPlanBookmark(principalDetails.getMemberId(), planId));
     }
 
 }

--- a/src/main/java/Journey/Together/domain/bookbark/entity/PlaceBookmark.java
+++ b/src/main/java/Journey/Together/domain/bookbark/entity/PlaceBookmark.java
@@ -7,7 +7,12 @@ import Journey.Together.domain.member.entity.Member;
 import Journey.Together.domain.place.entity.Place;
 import Journey.Together.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter

--- a/src/main/java/Journey/Together/domain/member/controller/AuthController.java
+++ b/src/main/java/Journey/Together/domain/member/controller/AuthController.java
@@ -40,14 +40,14 @@ public class AuthController {
     @PostMapping("/sign-out")
     public ApiResponse<Void> signOut(HttpServletRequest request, @AuthenticationPrincipal PrincipalDetails principalDetails) {
         String token = request.getHeader("Authorization");
-        authService.signOut(token, principalDetails.getMember());
+        authService.signOut(token, principalDetails.getMemberId());
         return ApiResponse.success(Success.SIGNOUT_SUCCESS);
     }
 
     @Operation(summary = "회원탈퇴 API", description = "회원탈퇴 등록")
     @DeleteMapping("/withdrawal")
     public ApiResponse<Void> withdrawal(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        authService.withdrawal(principalDetails.getMember());
+        authService.withdrawal(principalDetails.getMemberId());
         return ApiResponse.success(Success.DELETE_USER_SUCCESS);
     }
 
@@ -59,6 +59,6 @@ public class AuthController {
         if (token == null || !token.startsWith("Bearer ")) {
             return ApiResponse.success(Success.LOGIN_SUCCESS);
         }
-        return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS,authService.reissue(token, principalDetails.getMember()));
+        return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS,authService.reissue(token, principalDetails.getMemberId()));
     }
 }

--- a/src/main/java/Journey/Together/domain/member/controller/MemberController.java
+++ b/src/main/java/Journey/Together/domain/member/controller/MemberController.java
@@ -22,25 +22,25 @@ public class MemberController {
 
     @PatchMapping ("")
     public ApiResponse saveMemberInfo(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestPart(required = false) MultipartFile profileImage, @RequestPart(required = false) MemberReq memberReq) {
-        memberService.saveInfo(principalDetails.getMember(),profileImage,memberReq);
+        memberService.saveInfo(principalDetails.getMemberId(),profileImage,memberReq);
         return ApiResponse.success(Success.UPDATE_USER_INFO_SUCCESS);
     }
 
     @GetMapping("")
     public ApiResponse<MemberRes> findMemberInfo(@AuthenticationPrincipal PrincipalDetails principalDetails){
-        MemberRes memberRes = memberService.findMemberInfo(principalDetails.getMember());
+        MemberRes memberRes = memberService.findMemberInfo(principalDetails.getMemberId());
         return ApiResponse.success(Success.GET_MYPAGE_SUCCESS,memberRes);
     }
 
     @PatchMapping("/interest-type")
     public ApiResponse updateInterestType(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody InterestDto interestDto) {
-        memberService.updateMemberInterest(principalDetails.getMember(),interestDto);
+        memberService.updateMemberInterest(principalDetails.getMemberId(),interestDto);
         return ApiResponse.success(Success.UPDATE_USER_INFO_SUCCESS);
     }
 
     @GetMapping("/interest-type")
     public ApiResponse<InterestDto> findInterestType(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        InterestDto interestDto = memberService.findMemberInterest(principalDetails.getMember());
+        InterestDto interestDto = memberService.findMemberInterest(principalDetails.getMemberId());
         return ApiResponse.success(Success.GET_USER_INTEREST_SUCCESS,interestDto);
     }
 }

--- a/src/main/java/Journey/Together/domain/member/controller/MyPageController.java
+++ b/src/main/java/Journey/Together/domain/member/controller/MyPageController.java
@@ -26,7 +26,7 @@ public class MyPageController {
 
     @GetMapping
     public ApiResponse<MyPageRes> getMyPage(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, memberService.getMypage(principalDetails.getMember()));
+        return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, memberService.getMypage(principalDetails.getMemberId()));
     }
 
 }

--- a/src/main/java/Journey/Together/domain/place/controller/PlaceController.java
+++ b/src/main/java/Journey/Together/domain/place/controller/PlaceController.java
@@ -48,7 +48,7 @@ public class PlaceController {
     @GetMapping("/{placeId}")
     public ApiResponse<PlaceDetailRes> getPlaceDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @PathVariable Long placeId){
-        return ApiResponse.success(Success.GET_PLACE_DETAIL_SUCCESS, placeService.getPlaceDetail(principalDetails.getMember(), placeId));
+        return ApiResponse.success(Success.GET_PLACE_DETAIL_SUCCESS, placeService.getPlaceDetail(principalDetails.getMemberId(), placeId));
     }
 
     @GetMapping("guest/{placeId}")
@@ -62,14 +62,14 @@ public class PlaceController {
                                        @RequestPart PlaceReviewReq placeReviewReq,
                                        @PathVariable Long placeId) {
         images = (images == null) ? new ArrayList<>() : images;
-        placeService.createReview(principalDetails.getMember(), images,placeReviewReq, placeId);
+        placeService.createReview(principalDetails.getMemberId(), images,placeReviewReq, placeId);
         return ApiResponse.success(Success.CREATE_PLACE_REVIEW_SUCCESS);
     }
 
     @GetMapping("/review/{placeId}")
     public ApiResponse<PlaceReviewRes> getPlaceReview(@AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long placeId, @PageableDefault(size = 5,page = 0) Pageable pageable) {
-        return ApiResponse.success(Success.GET_PLACE_REVIEW_LIST_SUCCESS, placeService.getReviews(principalDetails.getMember(), placeId, pageable));
+        return ApiResponse.success(Success.GET_PLACE_REVIEW_LIST_SUCCESS, placeService.getReviews(principalDetails.getMemberId(), placeId, pageable));
     }
 
     @GetMapping("/review/guest/{placeId}")
@@ -81,20 +81,20 @@ public class PlaceController {
     @GetMapping("/review/my")
     public ApiResponse<MyPlaceReviewRes> getPlaceMyReviews(
             @AuthenticationPrincipal PrincipalDetails principalDetails,@PageableDefault(size = 5,page = 0) Pageable pageable) {
-        return ApiResponse.success(Success.GET_MY_PLACE_REVIEW_LIST_SUCCESS, placeService.getMyReviews(principalDetails.getMember(), pageable));
+        return ApiResponse.success(Success.GET_MY_PLACE_REVIEW_LIST_SUCCESS, placeService.getMyReviews(principalDetails.getMemberId(), pageable));
     }
 
     @DeleteMapping("/review/my/{reviewId}")
     public ApiResponse<?> deletePlaceMyReview(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long reviewId) {
-        placeService.deleteMyPlaceReview(principalDetails.getMember(),reviewId);
+        placeService.deleteMyPlaceReview(principalDetails.getMemberId(),reviewId);
         return ApiResponse.success(Success.DELETE_MY_PLACE_REVIEW_SUCCESS);
     }
 
     @GetMapping("/review/my/{reviewId}")
     public ApiResponse<MyReview> getPlaceMyReview(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long reviewId) {
-        return ApiResponse.success(Success.GET_MY_PLACE_REVIEW_SUCCESS,placeService.getReview(principalDetails.getMember(),reviewId));
+        return ApiResponse.success(Success.GET_MY_PLACE_REVIEW_SUCCESS,placeService.getReview(principalDetails.getMemberId(),reviewId));
     }
 
     @PatchMapping("/review/my/{reviewId}")
@@ -104,7 +104,7 @@ public class PlaceController {
             @RequestPart(required = false) List<MultipartFile> addImages,
             @PathVariable Long reviewId) {
         addImages = (addImages == null) ? new ArrayList<>() : addImages;
-        placeService.updateMyPlaceReview(principalDetails.getMember(),updateReviewDto,addImages,reviewId);
+        placeService.updateMyPlaceReview(principalDetails.getMemberId(),updateReviewDto,addImages,reviewId);
         return ApiResponse.success(Success.UPDATE_MY_PLACE_REVIEW_SUCCESS);
     }
     @GetMapping("/search")

--- a/src/main/java/Journey/Together/domain/plan/controller/PlanController.java
+++ b/src/main/java/Journey/Together/domain/plan/controller/PlanController.java
@@ -23,30 +23,30 @@ public class PlanController {
     private final PlanService planService;
     @PostMapping("")
     public ApiResponse savePlan(@AuthenticationPrincipal PrincipalDetails principalDetails,@RequestBody PlanReq planReq){
-        planService.savePlan(principalDetails.getMember(),planReq);
+        planService.savePlan(principalDetails.getMemberId(),planReq);
         return ApiResponse.success(Success.CREATE_PLAN_SUCCESS);
     }
 
     @PatchMapping("/{plan_id}")
     public ApiResponse updatePlan(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id") Long planId, @RequestBody PlanReq planReq){
-        planService.updatePlan(principalDetails.getMember(),planId,planReq);
+        planService.updatePlan(principalDetails.getMemberId(),planId,planReq);
         return ApiResponse.success(Success.UPDATE_PLAN_SUCCESS);
     }
 
     @GetMapping("/{plan_id}")
     public ApiResponse<PlanRes> findPlan(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id") Long planId){
-        return ApiResponse.success(Success.GET_PLAN_SUCCESS,planService.findPlan(principalDetails.getMember(),planId));
+        return ApiResponse.success(Success.GET_PLAN_SUCCESS,planService.findPlan(principalDetails.getMemberId(),planId));
     }
 
     @DeleteMapping("/{plan_id}")
     public ApiResponse deletePlan(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id") Long planId){
-        planService.deletePlan(principalDetails.getMember(),planId);
+        planService.deletePlan(principalDetails.getMemberId(),planId);
         return ApiResponse.success(Success.DELETE_PLAN_SUCCESS);
     }
 
     @PatchMapping("/{plan_id}/ispublic")
     public ApiResponse updatePlanIsPublic(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("plan_id") Long planId){
-        return ApiResponse.success(Success.UPDATE_PLAN_SUCCESS,planService.updatePlanIsPublic(principalDetails.getMember(),planId));
+        return ApiResponse.success(Success.UPDATE_PLAN_SUCCESS,planService.updatePlanIsPublic(principalDetails.getMemberId(),planId));
     }
 
     @GetMapping("/search")
@@ -56,24 +56,24 @@ public class PlanController {
 
     @PostMapping("/review/{plan_id}")
     public ApiResponse savePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId, @RequestPart(required = false) List<MultipartFile> images, @RequestPart PlanReviewReq planReviewReq){
-        planService.savePlanReview(principalDetails.getMember(),planId,planReviewReq,images);
+        planService.savePlanReview(principalDetails.getMemberId(),planId,planReviewReq,images);
         return ApiResponse.success(Success.CREATE_REVIEW_SUCCESS);
     }
 
     @GetMapping("/review/{plan_id}")
     public ApiResponse<PlanReviewRes> findPlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId){
-        return ApiResponse.success(Success.GET_REVIEW_SUCCESS,planService.findPlanReview(principalDetails.getMember(),planId));
+        return ApiResponse.success(Success.GET_REVIEW_SUCCESS,planService.findPlanReview(principalDetails.getMemberId(),planId));
     }
 
     @PatchMapping("/review/{review_id}")
     public ApiResponse updatePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("review_id")Long reviewId, @RequestPart(required = false) List<MultipartFile> images, @RequestPart(required = false) UpdatePlanReviewReq planReviewReq){
-        planService.updatePlanReview(principalDetails.getMember(),reviewId,planReviewReq,images);
+        planService.updatePlanReview(principalDetails.getMemberId(),reviewId,planReviewReq,images);
         return ApiResponse.success(Success.UPDATE_REVIEW_SUCCESS);
     }
 
     @DeleteMapping("/review/{review_id}")
     public ApiResponse deletePlanReview(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("review_id")Long reviewId){
-        planService.deletePlanReview(principalDetails.getMember(),reviewId);
+        planService.deletePlanReview(principalDetails.getMemberId(),reviewId);
         return ApiResponse.success(Success.DELETE_PLAN_REVIEW_SUCCESS);
     }
 
@@ -89,7 +89,7 @@ public class PlanController {
 
     @GetMapping("/detail/{plan_id}")
     public ApiResponse<PlanDetailRes> findPalnDetailInfo(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("plan_id")Long planId){
-        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findPlanDetail(principalDetails.getMember(),planId));
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findPlanDetail(principalDetails.getMemberId(),planId));
     }
 
     @GetMapping("/guest/detail/{plan_id}")
@@ -99,16 +99,16 @@ public class PlanController {
 
     @GetMapping("/my")
     public ApiResponse<List<MyPlanRes>> findMyPlans(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(Success.GET_MYPLAN_SUCCESS,planService.findMyPlans(principalDetails.getMember()));
+        return ApiResponse.success(Success.GET_MYPLAN_SUCCESS,planService.findMyPlans(principalDetails.getMemberId()));
     }
 
     @GetMapping("/my/not-complete")
     public ApiResponse<PlanPageRes> findNotComplete(@AuthenticationPrincipal PrincipalDetails principalDetails,@PageableDefault(size = 6,page = 0) Pageable pageable){
-        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findIsCompelete(principalDetails.getMember(),pageable,false));
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findIsCompelete(principalDetails.getMemberId(),pageable,false));
     }
     @GetMapping("/my/complete")
     public ApiResponse<PlanPageRes> findComplete(@AuthenticationPrincipal PrincipalDetails principalDetails,@PageableDefault(size = 6) Pageable pageable){
-        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findIsCompelete(principalDetails.getMember(),pageable,true));
+        return ApiResponse.success(Success.SEARCH_SUCCESS,planService.findIsCompelete(principalDetails.getMemberId(),pageable,true));
     }
 
 }

--- a/src/main/java/Journey/Together/domain/report/controller/ReportController.java
+++ b/src/main/java/Journey/Together/domain/report/controller/ReportController.java
@@ -38,13 +38,13 @@ public class ReportController {
                                              @PageableDefault(size = 10,page = 0) Pageable pageable
                                      ){
         return ApiResponse.success(Success.CREATE_RERORT_SUCCESS,
-                reportService.getReports(principalDetails.getMember(), approval, reason, reviewType, pageable));
+                reportService.getReports(principalDetails.getMemberType(), approval, reason, reviewType, pageable));
     }
 
     @PatchMapping()
     public ApiResponse<?> setAprrovalStatus(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                             @RequestBody ApprovalDto approvalDto){
-            reportService.setApprovalStatus(principalDetails.getMember(), approvalDto);
+            reportService.setApprovalStatus(principalDetails.getMemberType(), approvalDto);
         return ApiResponse.success(Success.UPDATE_APPROVAL_SUCCESS);
     }
 

--- a/src/main/java/Journey/Together/domain/report/service/ReportService.java
+++ b/src/main/java/Journey/Together/domain/report/service/ReportService.java
@@ -71,8 +71,8 @@ public class ReportService {
         }
     }
 
-    public ReportRes getReports(Member member, Boolean approval, String reason, String reviewType, Pageable pageable) {
-        if(!member.getMemberType().equals(MemberType.ADMIN)){
+    public ReportRes getReports(MemberType memberType, Boolean approval, String reason, String reviewType, Pageable pageable) {
+        if(!memberType.equals(MemberType.ADMIN)){
             throw new ApplicationException(ErrorCode.WRONG_ACCESS_EXCEPTION);
         }
 
@@ -102,8 +102,8 @@ public class ReportService {
     }
 
     @Transactional
-    public void setApprovalStatus(Member member, ApprovalDto approvalDto) {
-        if(!member.getMemberType().equals(MemberType.ADMIN)){
+    public void setApprovalStatus(MemberType memberType, ApprovalDto approvalDto) {
+        if(!memberType.equals(MemberType.ADMIN)){
             throw new ApplicationException(ErrorCode.WRONG_ACCESS_EXCEPTION);
         }
 

--- a/src/main/java/Journey/Together/global/security/PrincipalDetails.java
+++ b/src/main/java/Journey/Together/global/security/PrincipalDetails.java
@@ -1,6 +1,7 @@
 package Journey.Together.global.security;
 
 import Journey.Together.domain.member.entity.Member;
+import Journey.Together.domain.member.enumerate.MemberType;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,39 +15,38 @@ import java.util.Map;
 public class PrincipalDetails implements UserDetails, OAuth2User {
 
     @Getter
-    private final Member member;
+    private String email;
+
+    @Getter
+    private MemberType memberType;
+
+    @Getter
+    private Long memberId;
     private Map<String, Object> attributes;
 
     // 일반 로그인
-    public PrincipalDetails(Member member) {
-        this.member = member;
-    }
-
-    // OAuth 로그인
-    public PrincipalDetails(Member member, Map<String, Object> attributes) {
-        this.member = member;
-        this.attributes = attributes;
+    public PrincipalDetails(String email, MemberType memberType, Long memberId) {
+        this.email = email;
+        this.memberType = memberType;
+        this.memberId = memberId;
     }
 
     // 권한 정보 반환 (GENERAL, ADMIN 중 하나)
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        authorities.add(new SimpleGrantedAuthority(String.valueOf(member.getMemberType())));
+        authorities.add(new SimpleGrantedAuthority(String.valueOf(memberType)));
 
         return authorities;
     }
 
-    // 사용자의 비밀번호 반환
-    @Override
-    public String getPassword() {
-        return member.getPassword();
-    }
-
     // 사용자의 이름 반환
     @Override
-    public String getUsername() {
-        return member.getName();
+    public String getUsername() { return null; }
+
+    @Override
+    public String getPassword() {
+        return null;  // 패스워드는 JWT 인증 방식에서 필요하지 않음
     }
 
     // 계정이 잠기지 않았으므로 true 반환

--- a/src/main/java/Journey/Together/global/security/jwt/JwtFilter.java
+++ b/src/main/java/Journey/Together/global/security/jwt/JwtFilter.java
@@ -32,7 +32,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        // 토큰이 존재할 경우, Authentication에 인증 정보 저장 및 로그 출력
+        // 토큰이 존재할 경우, Authentication에 인증 정보 저장
         if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);


### PR DESCRIPTION
## 🚩 관련 이슈
- close #113 

## 📋 구현 기능 명세
- [x] getAuthentication 함수에서 DB 조회 로직 삭제
- [x] PrincipalDetails에 email, memberType, id 처럼 불변이고 보안적으로 문제없는 값을 저장
- [x] PrincipalDetails.getMember() 로직 모두 수정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
현재 로직에서는 `jwt 필터`에서` tokenProvider.getAuthentication(token)`으로 `Authentication` 객체 반환 ->
`getAuthentication` 함수 내부적으로는 token에서 이메일과 멤버타입 정보를 가지고 **DB에서 member 객체를 조회**하여 `PrincipalDetails` 저장함

현재 로직은 모든 api가 jwt 필터를 지나면서 매번 DB를 조회한다. -> 사용자가 많으면 DB 부하 증가
-> JWT의 장점 중 하나는 클라이언트가 전달하는 토큰 자체에 사용자 정보를 포함하고 있어 서버가 상태를 저장할 필요가 없다는 것인데, 이 코드에서는 매 요청마다 DB에서 사용자 정보를 조회하고 있다.  (사용자 정보가 조회하지않아도 되는 api도 무조건 조회되고 있음)

- 어떤 부분에 리뷰어가 집중해야 하는지
getMember 대신 모두 memberId로 변경했는데 혹시 중간에 이상하게 변경한 부분이 있는지,,, 너무 많아서 실수 있을까봐 두렵다...

- 개발하면서 어떤 점이 궁금했는지

## 🛠️ 테스트
- [x] 테스트
