### PR TITLE
 [#138] feat: 메인화면 추천 장소 이미지 없는 장소 제외

### DIFF
--- a/src/main/java/Journey/Together/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/Journey/Together/domain/place/repository/PlaceRepository.java
@@ -12,14 +12,19 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceRepositoryCustom {
-
-    @Query(value = "SELECT * FROM place p WHERE p.first_img IS NOT NULL AND p.first_img <> '' ORDER BY RAND() LIMIT :count", nativeQuery = true)
+    @Query(value = "SELECT * FROM place p " +
+        "WHERE p.first_img IS NOT NULL AND TRIM(p.first_img) <> '' " +
+        "ORDER BY RAND() LIMIT :count", nativeQuery = true)
     List<Place> findRandomProducts(@Param("count") int count);
 
-    @Query(value = "SELECT * FROM place p WHERE p.first_img IS NOT NULL AND p.first_img <> '' AND area_code = :areacode AND sigungu_code = :sigungucode " +
-            "ORDER BY RAND() LIMIT :count", nativeQuery = true)
-    List<Place> findAroundProducts(@Param("areacode") String areacode, @Param("sigungucode") String sigungucode,
-                                   @Param("count") int count);
+    @Query(value = "SELECT * FROM place p " +
+        "WHERE p.first_img IS NOT NULL AND TRIM(p.first_img) <> '' " +
+        "AND area_code = :areacode AND sigungu_code = :sigungucode " +
+        "ORDER BY RAND() LIMIT :count", nativeQuery = true)
+    List<Place> findAroundProducts(@Param("areacode") String areacode,
+        @Param("sigungucode") String sigungucode,
+        @Param("count") int count);
+
 
     Place findPlaceById(Long id);
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #138 

## 📋 구현 기능 명세
- [x] 메인화면 추천 장소 이미지 없는 장소 제외

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
메인화면 추천 장소 이미지없는것이 내려온다하여 기존 NULL 제외와 함께 빈 문자열일경우도 제외하도록 추가하였습니다.

