### PR TITLE
[Feat/#142] docker -> docker-compose로 컨테이너 관리 변경

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -46,44 +46,50 @@ jobs:
             -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }} \
             --push .
 
-      - name: Blue-Green Deploy to EC2
+      - name: Blue-Green Deploy to EC2 (compose)
         uses: appleboy/ssh-action@v0.1.6
         with:
           host: ${{ secrets.EC2_SERVER_IP }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            if docker ps | grep app-blue; then
-              NEXT_PORT=8081
+            export REGISTRY_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:latest
+
+            if docker ps --format '{{.Names}}' | grep -q '^app-blue$'; then
+              NEXT_PROFILE=green
               NEXT_NAME=app-green
-              NEXT_CONF=green.conf
+              CURRENT_PROFILE=blue
               CURRENT_NAME=app-blue
+              NEXT_PORT=8081
+              NEXT_CONF=green.conf
             else
-              NEXT_PORT=8080
+              NEXT_PROFILE=blue
               NEXT_NAME=app-blue
-              NEXT_CONF=blue.conf
+              CURRENT_PROFILE=green
               CURRENT_NAME=app-green
+              NEXT_PORT=8080
+              NEXT_CONF=blue.conf
             fi
 
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}
+            docker compose --profile $NEXT_PROFILE pull $NEXT_NAME
+            docker compose --profile $NEXT_PROFILE up -d $NEXT_NAME
 
-            docker stop $NEXT_NAME || true && docker rm $NEXT_NAME || true
-            docker run -d --name $NEXT_NAME -p $NEXT_PORT:8080 \
-              ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}
-    
             for i in {1..24}; do
-              if curl -fs http://localhost:$NEXT_PORT/actuator/health; then
+              if curl -fs http://localhost:${NEXT_PORT}/actuator/health; then
                 break
               fi
-              echo "Waiting for app on port $NEXT_PORT to be healthy... ($i/24)"
+              echo "Waiting for app on port ${NEXT_PORT} to be healthy... ($i/24)"
               sleep 5
             done
 
-            if curl -f http://localhost:$NEXT_PORT/actuator/health; then
-              ln -sf ~/nginx/$NEXT_CONF ~/nginx/nginx.conf
-              docker restart nginx
-              docker stop $CURRENT_NAME && docker rm $CURRENT_NAME
+            if curl -fs http://localhost:${NEXT_PORT}/actuator/health; then
+              ln -sfn ~/nginx/${NEXT_CONF} ~/nginx/nginx.conf
+              docker exec -T nginx nginx -s reload || docker compose restart nginx
+              docker --profile $CURRENT_PROFILE stop $CURRENT_NAME
+              docker --profile $CURRENT_PROFILE rm -f $CURRENT_NAME
             else
-              docker stop $NEXT_NAME && docker rm $NEXT_NAME
+              echo "New app failed health check. Rolling back..."
+              docker compose --profile $NEXT_PROFILE stop $NEXT_NAME
+              docker compose --profile $NEXT_PROFILE rm -f $NEXT_NAME
               exit 1
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 /src/main/resources/application.yml
 /src/main/resources/application-release.yml
 /src/main/resources/application-local.yml
+
+/docker-compose.yml

--- a/build.gradle
+++ b/build.gradle
@@ -86,9 +86,15 @@ dependencies {
 	// Jaro-Winkler
 	implementation 'org.apache.commons:commons-text:1.10.0'
 
+	//OpenFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.github.openfeign:feign-jackson:13.2'
+
+	//H2
 	runtimeOnly 'com.h2database:h2'
+
+	//Promethus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- #142 

## 📋 구현 기능 명세
- [x] docker -> docker-compose로 컨테이너 환경 변경
- [x] docker-compose에서 blue/green앱 변경 시, profile를 활용
- [x] 이에 맞게 cd.yml 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지

 grafana/promethus를 추가적으로 적용해야하는 상황에서, 기존의 docker로 개별 컨테이너로 관리하는 것보다 docker-compose로 여러개의 컨테이너를 여러개로 묶어 관리하면 용이할 것 같아 변경하였습니다. 그리고, docker-compose의 profile를 활용하여 blue/green 그룹화하였습니다.
nginx는 기존대로 docker 개별 컨테이너로 띄우는 것이 기존 환경 변경 최소화라고 생각하여 변경한 부분은 없습니다.

### profile이란?
- docker-compose.yml 안에서 서비스를 그룹화하거나 선택적으로 실행할 수 있도록 하는 기능.
- 특정 profile이 활성화될 때만 실행하도록 설정


