### PR TITLE
#147 fix: auth/sign-in만 JWTfilter 제외로 수정

### DIFF
--- a/src/main/java/Journey/Together/global/config/SecurityConfig.java
+++ b/src/main/java/Journey/Together/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                         "/v1/place/review/guest/**",
                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
                         "/actuator/**",
-                        "/v1/auth/**", "/oauth2/**", "/login.html")
+                        "/v1/auth/sign-in", "/oauth2/**", "/login.html")
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## 🚩 관련 이슈
- close #147 

## 📋 구현 기능 명세
- [x] 

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
guestChain에서 auth/**->auth/sign-in으로 로그인시에만 JWT필터 거치지 않도록 변경
