### PR TITLE
 [#154] fix: objectMapper 시간관련 설정 추가

### DIFF
--- a/src/main/java/Journey/Together/global/config/OpenFeignConfig.java
+++ b/src/main/java/Journey/Together/global/config/OpenFeignConfig.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Configuration;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import feign.Logger;
 import feign.QueryMapEncoder;
@@ -15,6 +17,7 @@ import feign.Retryer;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
 import feign.codec.Encoder;
+import feign.jackson.JacksonEncoder;
 import feign.querymap.BeanQueryMapEncoder;
 
 @Configuration
@@ -40,7 +43,10 @@ public class OpenFeignConfig {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // LocalDate, LocalDateTime 지원
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO 포맷으로
         objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return objectMapper;
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #154 

## 📋 구현 기능 명세
- [x] objectMapper localDate타입 설정 추가

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
기존에 직접만든 objectMapper에 LoaclDate 직렬화 관련 설정을 해주지않아 부트가 자동으로 붙여주는 JavaTimeModule이 등록되지 않음 → LocalDate 처리 불가
Feign Encoder/Decoder도 같은 ObjectMapper를 주입받아 사용하도록 수정

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
